### PR TITLE
Development

### DIFF
--- a/src/Pecee/SimpleRouter/RouterRoute.php
+++ b/src/Pecee/SimpleRouter/RouterRoute.php
@@ -97,7 +97,7 @@ class RouterRoute extends RouterEntry {
 
             if(count($parameterNames)) {
                 foreach($parameterNames as $name) {
-                    $parameters[$name] = isset($parameterValues[$name]) ? $parameterValues[$name] : null;
+                    $parameters[$name] = (isset($parameterValues[$name]) && !empty($parameterValues[$name])) ? $parameterValues[$name] : null;
                 }
             }
 


### PR DESCRIPTION
- If parameter is empty set the value to ```null``` in ```RouterRoute```.
- ```RouterRoute``` now throws ```RouterException``` is required parameter is not filled.