### PR TITLE
[BUGFIX] Fixed error with RouterGroup.

### DIFF
--- a/src/Pecee/SimpleRouter/RouterGroup.php
+++ b/src/Pecee/SimpleRouter/RouterGroup.php
@@ -37,9 +37,11 @@ class RouterGroup extends RouterEntry {
                 $this->parameters = $parameters;
                 return true;
             }
+
+            return null;
         }
 
-        return null;
+        return false;
     }
 
     public function renderRoute(Request $request) {


### PR DESCRIPTION
- Fixed error with RouterGroup causing group not to be rendered if no domain is available.