### PR TITLE
Latest development

### DIFF
--- a/src/Pecee/SimpleRouter/RouterBase.php
+++ b/src/Pecee/SimpleRouter/RouterBase.php
@@ -281,7 +281,7 @@ class RouterBase {
         }
 
         if($controller === null && $parameters === null && $this->loadedRoute !== null) {
-            return $this->processUrl($this->loadedRoute, null, $getParams);
+            return $this->processUrl($this->loadedRoute, null, null, $getParams);
         }
 
         $c = '';

--- a/src/Pecee/SimpleRouter/RouterBase.php
+++ b/src/Pecee/SimpleRouter/RouterBase.php
@@ -281,6 +281,7 @@ class RouterBase {
         }
 
         if($controller === null && $parameters === null && $this->loadedRoute !== null) {
+            $getParams = (is_array($getParams)) ? array_merge($_GET, $getParams) : $_GET;
             return $this->processUrl($this->loadedRoute, null, null, $getParams);
         }
 

--- a/src/Pecee/SimpleRouter/RouterBase.php
+++ b/src/Pecee/SimpleRouter/RouterBase.php
@@ -280,9 +280,18 @@ class RouterBase {
             throw new \InvalidArgumentException('Invalid type for getParams. Must be array or null');
         }
 
+        // Return current route if no options has been specified
         if($controller === null && $parameters === null && $this->loadedRoute !== null) {
             $getParams = (is_array($getParams)) ? array_merge($_GET, $getParams) : $_GET;
-            return $this->processUrl($this->loadedRoute, null, null, $getParams);
+
+            $url = parse_url(Request::getInstance()->getUri());
+            $url = $url['path'];
+
+            if(count($getParams)) {
+                $url .= '?' . $this->arrayToParams($getParams);
+            }
+
+            return $url;
         }
 
         $c = '';


### PR DESCRIPTION
- Fixed ```getParams``` not being passed when using ```getRoute``` on current route.
- Fixed merge current parameters with new provided ones when using ```getRoute```.
- Fixed getting current route not always returning current url.