### PR TITLE
[TASK] Csrf-token fixes + readded BaseCsrfVerifier.

### DIFF
--- a/src/Pecee/CsrfToken.php
+++ b/src/Pecee/CsrfToken.php
@@ -7,12 +7,6 @@ class CsrfToken {
 
     protected $token;
 
-    public function __construct() {
-        if($this->getToken() === null) {
-            $this->setToken($this->generateToken());
-        }
-    }
-
     /**
      * Generate random identifier for CSRF token
      * @return string
@@ -51,10 +45,18 @@ class CsrfToken {
      * @return string|null
      */
     public function getToken(){
-        if(isset($_COOKIE[self::CSRF_KEY])) {
+        if($this->hasToken()) {
             return $_COOKIE[self::CSRF_KEY];
         }
         return null;
+    }
+
+    /**
+     * Returns whether the csrf token has been defined
+     * @return bool
+     */
+    public function hasToken() {
+        return isset($_COOKIE[self::CSRF_KEY]);
     }
 
 }

--- a/src/Pecee/SimpleRouter/RouterBase.php
+++ b/src/Pecee/SimpleRouter/RouterBase.php
@@ -1,6 +1,7 @@
 <?php
 namespace Pecee\SimpleRouter;
 
+use Pecee\CsrfToken;
 use Pecee\Http\Middleware\BaseCsrfVerifier;
 use Pecee\Http\Request;
 
@@ -13,7 +14,7 @@ class RouterBase {
     protected $routes;
     protected $processedRoutes;
     protected $controllerUrlMap;
-    protected $backstack;
+    protected $backStack;
     protected $loadedRoute;
     protected $defaultNamespace;
     protected $baseCsrfVerifier;
@@ -23,14 +24,19 @@ class RouterBase {
 
     public function __construct() {
         $this->routes = array();
-        $this->backstack = array();
+        $this->backStack = array();
         $this->controllerUrlMap = array();
+        $this->baseCsrfVerifier = new BaseCsrfVerifier();
         $this->request = Request::getInstance();
+
+        $csrf = new CsrfToken();
+        $token = ($csrf->hasToken()) ? $csrf->getToken() : $csrf->generateToken();
+        $csrf->setToken($token);
     }
 
     public function addRoute(RouterEntry $route) {
         if($this->currentRoute !== null) {
-            $this->backstack[] = $route;
+            $this->backStack[] = $route;
         } else {
             $this->routes[] = $route;
         }
@@ -87,9 +93,9 @@ class RouterBase {
 
             $this->currentRoute = null;
 
-            if(count($this->backstack)) {
-                $backStack = $this->backstack;
-                $this->backstack = array();
+            if(count($this->backStack)) {
+                $backStack = $this->backStack;
+                $this->backStack = array();
 
                 // Route any routes added to the backstack
                 $this->processRoutes($backStack, $mergedSettings, $newPrefixes, true, $activeGroup);
@@ -174,7 +180,7 @@ class RouterBase {
      * @return array
      */
     public function getBackstack() {
-        return $this->backstack;
+        return $this->backStack;
     }
 
     /**


### PR DESCRIPTION
- Readded ```BaseCsrfVerifier``` middleware.
- Csrf-token expire time is now updated on each page refresh.
- CSRF-token update now happens after the route has been loaded, to ensure no faulty "Invalid csrf-token" exceptions.