### PR TITLE
[BUGFIX] Custom parameters regex is now working again.

### DIFF
--- a/src/Pecee/SimpleRouter/RouterEntry.php
+++ b/src/Pecee/SimpleRouter/RouterEntry.php
@@ -27,7 +27,7 @@ abstract class RouterEntry {
     public function __construct() {
         $this->settings = array();
         $this->settings['requestMethods'] = array();
-        $this->settings['parametersRegex'] = array();
+        $this->settings['where'] = array();
         $this->settings['parameters'] = array();
     }
 
@@ -155,7 +155,7 @@ abstract class RouterEntry {
      * @return self
      */
     public function where(array $options) {
-        $this->parametersRegex = array_merge($this->parametersRegex, $options);
+        $this->where = array_merge($this->where, $options);
         return $this;
     }
 
@@ -249,11 +249,6 @@ abstract class RouterEntry {
         $isParameter = false;
         $parameter = '';
 
-        // Use custom parameter regex if it exists
-        if(is_array($this->parametersRegex) && isset($this->parametersRegex[$parameter])) {
-            $parameterRegex = $this->parametersRegex[$parameter];
-        }
-
         $routeLength = strlen($route);
         for($i = 0; $i < $routeLength; $i++) {
 
@@ -275,6 +270,12 @@ abstract class RouterEntry {
             } elseif($isParameter && $character === '}') {
                 $required = true;
                 // Check for optional parameter
+
+                // Use custom parameter regex if it exists
+                if(is_array($this->where) && isset($this->where[$parameter])) {
+                    $parameterRegex = $this->where[$parameter];
+                }
+
                 if($lastCharacter === '?') {
                     $parameter = substr($parameter, 0, strlen($parameter)-1);
                     $regex .= '(?:(?:\/{0,1}(?P<'.$parameter.'>[^\/]*)))\\/{0,1}';

--- a/src/Pecee/SimpleRouter/RouterResource.php
+++ b/src/Pecee/SimpleRouter/RouterResource.php
@@ -88,7 +88,7 @@ class RouterResource extends RouterEntry {
             }
 
             // Show
-            if($action && $this->postMethod === self::REQUEST_TYPE_GET) {
+            if(isset($parameters['id']) && $this->postMethod === self::REQUEST_TYPE_GET) {
                 return $this->call('show', $parameters);
             }
 


### PR DESCRIPTION
- Fixed custom parameters regex not working.
- Renamed setting ```parameterRegex``` to ```match``` to match the Laravel
  documentation.
- Fixed ```show``` method in ressource controller not always called if using nested ressources.