### PR TITLE
Development

### DIFF
--- a/src/Pecee/Http/Input/Input.php
+++ b/src/Pecee/Http/Input/Input.php
@@ -49,12 +49,13 @@ class Input {
     }
 
     public function getObject($index, $default = null) {
+        $key = (strpos($index, '[') > -1) ? substr($index, strpos($index, '[')+1, strpos($index, ']') - strlen($index)) : null;
         $index = (strpos($index, '[') > -1) ? substr($index, 0, strpos($index, '[')) : $index;
 
         $element = $this->get->findFirst($index);
 
         if($element !== null) {
-            return $element;
+            return ($key !== null) ? $element[$key] : $element;
         }
 
         if(Request::getInstance()->getMethod() !== 'get') {
@@ -62,12 +63,12 @@ class Input {
             $element = $this->post->findFirst($index);
 
             if ($element !== null) {
-                return $element;
+                return ($key !== null) ? $element[$key] : $element;
             }
 
             $element = $this->file->findFirst($index);
             if ($element !== null) {
-                return $element;
+                return ($key !== null) ? $element[$key] : $element;
             }
         }
 
@@ -82,19 +83,12 @@ class Input {
      */
     public function get($index, $default = null) {
 
-        $key = (strpos($index, '[') > -1) ? substr($index, strpos($index, '[')+1, strpos($index, ']') - strlen($index)) : null;
-        $index = (strpos($index, '[') > -1) ? substr($index, 0, strpos($index, '[')) : $index;
-
         $item = $this->getObject($index);
 
         if($item !== null) {
 
             if($item instanceof InputFile) {
                 return $item;
-            }
-
-            if (is_array($item->getValue())) {
-                return ($key !== null && isset($item->getValue()[$key])) ? $item->getValue()[$key] : $item->getValue();
             }
 
             return (trim($item->getValue()) === '') ? $default : $item->getValue();
@@ -119,7 +113,7 @@ class Input {
                     $output[$k] = new InputItem($k, $g);
                 }
 
-                $this->get->{$key} = new InputItem($key, $output);
+                $this->get->{$key} = $output;
             }
         }
     }
@@ -149,7 +143,7 @@ class Input {
                     $output[$k] = new InputItem($k, $p);
                 }
 
-                $this->post->{strtolower($key)} = new InputItem($key, $output);
+                $this->post->{strtolower($key)} = $output;
             }
         }
     }
@@ -189,7 +183,7 @@ class Input {
                     }
                 }
 
-                $this->file->{strtolower($key)} = new InputItem($key, $output);
+                $this->file->{strtolower($key)} = $output;
             }
         }
     }

--- a/src/Pecee/Http/Input/Input.php
+++ b/src/Pecee/Http/Input/Input.php
@@ -87,7 +87,7 @@ class Input {
 
         if($item !== null) {
 
-            if($item instanceof InputFile) {
+            if(is_array($item) || $item instanceof InputFile) {
                 return $item;
             }
 

--- a/src/Pecee/SimpleRouter/RouterBase.php
+++ b/src/Pecee/SimpleRouter/RouterBase.php
@@ -303,13 +303,17 @@ class RouterBase {
     }
 
     public function arrayToParams(array $getParams = null, $includeEmpty = true) {
-        if (is_array($getParams) && count($getParams) > 0) {
-            foreach ($getParams as $key => $val) {
-                if (!empty($val) || $includeEmpty) {
-                    $getParams[$key] = (is_array($val) ? $this->arrayToParams($val, $includeEmpty) : $key . '=' . $val);
-                }
+
+        if(is_array($getParams)) {
+            if ($includeEmpty === false) {
+                $getParams = array_filter($getParams, function ($item) {
+                    if (!empty($item)) {
+                        return $item;
+                    }
+                });
             }
-            return join('&', $getParams);
+
+            return http_build_query($getParams);
         }
         return '';
     }
@@ -386,8 +390,7 @@ class RouterBase {
         if($controller === null && $parameters === null) {
             $getParams = (is_array($getParams)) ? array_merge($_GET, $getParams) : $_GET;
 
-            $url = parse_url(Request::getInstance()->getUri());
-            $url = $url['path'];
+            $url = parse_url($this->request->getUri(), PHP_URL_PATH);
 
             if(count($getParams)) {
                 $url .= '?' . $this->arrayToParams($getParams);

--- a/src/Pecee/SimpleRouter/RouterGroup.php
+++ b/src/Pecee/SimpleRouter/RouterGroup.php
@@ -98,4 +98,14 @@ class RouterGroup extends RouterEntry {
         return $this;
     }
 
+    public function getMergeableSettings() {
+        $settings = parent::getMergeableSettings();
+
+        if(isset($settings['middleware'])) {
+            unset($settings['middleware']);
+        }
+
+        return $settings;
+    }
+
 }


### PR DESCRIPTION
- Input class now returns array instead of `InputItem` instance when object is of `array`.
- Optimized key behavior in `Input` class.
- Optimized `arrayToParams` method in `RouterBase` class.
- Added `getMergableSettings` method to `RouterGroup` to avoid middleware merge; as they will already be loaded.
- Return `$item` if it's an array in get method in `Input` class.