### PR TITLE
Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ This is some sites that uses the simple-router project in production.
 
 - [holla.dk](http://www.holla.dk)
 - [ninjaimg.com](http://ninjaimg.com)
+- [bookandbegin.com](https://bookandbegin.com)
 
 ## Documentation
 While I work on a better documentation, please refer to the Laravel 5 routing documentation here:

--- a/src/Pecee/SimpleRouter/RouterBase.php
+++ b/src/Pecee/SimpleRouter/RouterBase.php
@@ -131,6 +131,14 @@ class RouterBase {
         // Loop through each route-request
         $this->processRoutes($this->routes);
 
+        // Make sure routes with longer urls are rendered first
+        usort($this->controllerUrlMap, function($a, $b) {
+            if(strlen($a->getUrl()) < strlen($b->getUrl())) {
+                return 1;
+            }
+            return -1;
+        });
+
         $routeNotAllowed = false;
 
         $max = count($this->controllerUrlMap);

--- a/src/Pecee/SimpleRouter/RouterEntry.php
+++ b/src/Pecee/SimpleRouter/RouterEntry.php
@@ -249,7 +249,7 @@ abstract class RouterEntry {
         return new $name();
     }
 
-    protected function parseParameters($route, $url, $parameterRegex = '[a-z0-9]+') {
+    protected function parseParameters($route, $url, $parameterRegex = '[\w]+') {
         $parameterNames = array();
         $regex = '';
         $lastCharacter = '';
@@ -288,7 +288,7 @@ abstract class RouterEntry {
                     $regex .= '(?:\\/?(?P<'.$parameter.'>[^\/]+)?\\/?)';
                     $required = false;
                 } else {
-                    $regex .= '\\/(?P<' . $parameter . '>'. $parameterRegex .')\\/';
+                    $regex .= '.*?(?P<' . $parameter . '>'. $parameterRegex .').*?';
                 }
                 $parameterNames[] = array('name' => $parameter, 'required' => $required);
                 $parameter = '';
@@ -307,7 +307,7 @@ abstract class RouterEntry {
 
         $parameterValues = array();
 
-        if(preg_match('/^'.$regex.'$/is', $url, $parameterValues)) {
+        if(preg_match('/^'.$regex.'.?$/is', $url, $parameterValues)) {
             $parameters = array();
 
             $max = count($parameterNames);

--- a/test/MiddlewareTest.php
+++ b/test/MiddlewareTest.php
@@ -20,17 +20,16 @@ class MiddlewareTest extends PHPUnit_Framework_TestCase  {
 
         \Pecee\SimpleRouter\SimpleRouter::get('/my/test/url', 'DummyController@start', ['middleware' => 'DummyMiddleware']);
 
+        $found = false;
+
         try {
             \Pecee\SimpleRouter\SimpleRouter::start();
         }catch(Exception $e) {
-            $this->assertTrue(($e instanceof MiddlewareLoadedException));
-            return;
+            $found = ($e instanceof MiddlewareLoadedException);
         }
 
-        throw new Exception('Middleware not loaded');
+        $this->assertTrue($found);
 
     }
-
-
 
 }


### PR DESCRIPTION
- Optimized the way parameters are parsed as a result, simple-router now supports routes like `/{param1}-{param2}.json`.

- Replaced reg-ex for parameter-matching with `\w` which means that default parameter matching on routes now include `_` (underscore) per default.

- Simplified `MiddlewareTest` class.
- Added contributing site in Readme.