### PR TITLE
Allow for default parameters (including A-Z, a-z, 0-9 and "-") when p…

### DIFF
--- a/src/Pecee/SimpleRouter/RouterResource.php
+++ b/src/Pecee/SimpleRouter/RouterResource.php
@@ -52,7 +52,7 @@ class RouterResource extends RouterEntry {
 
         $route = rtrim($this->url, '/') . '/{id?}/{action?}';
 
-        $parameters = $this->parseParameters($route, $url, '[0-9]+?');
+        $parameters = $this->parseParameters($route, $url);
 
         if($parameters !== null) {
 


### PR DESCRIPTION
Allow for default parameters (including A-Z, a-z, 0-9 and "-") when parsing parameters in `RouterResource` class.