### PR TITLE
Automatically push middlewares if multiple in nested group.

### DIFF
--- a/src/Pecee/SimpleRouter/RouterGroup.php
+++ b/src/Pecee/SimpleRouter/RouterGroup.php
@@ -93,9 +93,23 @@ class RouterGroup extends RouterEntry {
             unset($settings['namespace']);
         }
 
+        // Push middleware if multiple
+        if($this->getMiddleware() !== null && isset($settings['middleware'])) {
+
+            if(!is_array($this->getMiddleware())) {
+                $middlewares = [$this->getMiddleware(), $settings['middleware']];
+            } else {
+                $middlewares = array_push($settings['middleware']);
+            }
+
+            $settings['middleware'] = array_unique($middlewares);
+
+        }
+
         if(is_array($settings)) {
             $this->settings = array_merge($this->settings, $settings);
         }
+
         return $this;
     }
 


### PR DESCRIPTION
**Example:**

```php
Router::group(['middleware' => '\DailyFix\Middleware\LanguageDetection'], function() {
    Router::group(['prefix' => '/dashboard', 'namespace' => '\DailyFix\Controller\Dashboard', 'middleware' => '\DailyFix\Middleware\DashboardAccess'], function() {
        Router::controller('/', 'DefaultController');
    });
});
```

Will now automatically push middlewares as you would expect, so `LanguageDetection` is loaded first followed by `DashboardAccess`. 