### PR TITLE
V2 development

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,15 +354,16 @@ By doing this the route will now load the url ```/article/view/1``` instead of `
 The last thing we need to do, is to add our custom boot-manager to the ```routes.php``` file. You can create as many bootmanagers as you like and easily add them in your ```routes.php``` file.
 
 ## Easily overwrite route about to be loaded
-Sometimes it can be useful to manipulate the route that's about to be loaded, for instance if a user is not authenticated or if an error occurred within your Middleware that requires
-some other route to be initialised. Simple PHP Router allows you to easily change the route about to be executed. All information about the current route is stored in
-the ```\Pecee\SimpleRouter\Http\Request``` object. All information about the current route is as a ```\Pecee\SimpleRouter\Http\Request``` object which can always be obtained on 
-the `RouterBase` instance. For easy access you can use the shortcut method `\Pecee\SimpleRouter\SimpleRouter::request()`.
+Sometimes it can be useful to manipulate the route about to be loaded. 
+simple-php-router allows you to easily change the route about to be executed. 
+All information about the current route is stored in the ```\Pecee\SimpleRouter\RouterBase``` instance. 
 
-**Note:** Please note that it's only possible to change the route BEFORE any route has initially been loaded, so doing this in your custom ExceptionHandler or Middleware is highly recommended.
+For easy access you can use the shortcut method `\Pecee\SimpleRouter\SimpleRouter::router()`.
+
 
 ```php
-$route = request()->getLoadedRoute();
+use Pecee\SimpleRouter;
+$route = SimpleRouter::router()->getLoadedRoute();
 
 $route->setCallback('Example\MyCustomClass@hello');
 
@@ -370,6 +371,54 @@ $route->setCallback('Example\MyCustomClass@hello');
 
 $route->setClass('Example\MyCustomClass');
 $route->setMethod('hello');
+```
+
+
+### Examples
+
+#### Faking new route
+It's only possible to change the route BEFORE the route has initially been loaded. If you want to redirect to another route, we highly recommend that you 
+modify the `RouterRoute` object from a `Middleware` or `ExceptionHandler`, for like the examples below.
+
+The example below will cause the router to re-route the request with the "fake" uri. This does require the `$request` object to be returned, 
+otherwise the `request` object will be ignored by the router.
+
+```php
+namespace demo\Middlewares;
+
+use Pecee\Http\Middleware\IMiddleware;
+use Pecee\Http\Request;
+use Pecee\SimpleRouter\RouterEntry;
+
+class CustomMiddleware implements Middleware {
+
+    public function handle(Request $request, RouterEntry &$route = null) {
+        return $request->setUri('/home');
+    }
+}
+
+```
+
+#### Changing callback
+You can also change the callback by modifying the `$route` parameter. This is perfect if you just want to display a view quickly - or change the callback depending
+on some criteria's for the request.
+
+The callback below will fire immediately after the `Middleware` or `ExceptionHandler` has been loaded, as they are loaded before the route is rendered.
+If you wish to change the callback from outside, please have this in mind.
+
+```php
+namespace demo\Middlewares;
+
+use Pecee\Http\Middleware\IMiddleware;
+use Pecee\Http\Request;
+use Pecee\SimpleRouter\RouterEntry;
+
+class CustomMiddleware implements Middleware {
+
+    public function handle(Request $request, RouterEntry &$route = null) { 
+        $route->callback('DefaultController@home');
+    }
+}
 ```
 
 ## Using the Input class to manage parameters
@@ -425,7 +474,7 @@ Below example requires you to have the helper functions added. Please refer to t
 
 ```php
 // Get parameter site_id or default-value 2
-$value = input()->get('site_id', '2');
+$siteId = input()->get('site_id', 2);
 ```
 
 ## Sites

--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ class CustomMiddleware implements Middleware {
     public function handle(Request $request, RouterEntry &$route = null) {
         return $request->setUri('/home');
     }
+    
 }
 
 ```
@@ -418,6 +419,7 @@ class CustomMiddleware implements Middleware {
     public function handle(Request $request, RouterEntry &$route = null) { 
         $route->callback('DefaultController@home');
     }
+    
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ The last thing we need to do, is to add our custom boot-manager to the ```routes
 ## Easily overwrite route about to be loaded
 Sometimes it can be useful to manipulate the route about to be loaded. 
 simple-php-router allows you to easily change the route about to be executed. 
-All information about the current route is stored in the ```\Pecee\SimpleRouter\RouterBase``` instance. 
+All information about the current route is stored in the ```\Pecee\SimpleRouter\RouterBase``` instance's `loadedRoute` property. 
 
 For easy access you can use the shortcut method `\Pecee\SimpleRouter\SimpleRouter::router()`.
 
@@ -376,12 +376,19 @@ $route->setMethod('hello');
 
 ### Examples
 
-#### Faking new route
 It's only possible to change the route BEFORE the route has initially been loaded. If you want to redirect to another route, we highly recommend that you 
-modify the `RouterRoute` object from a `Middleware` or `ExceptionHandler`, for like the examples below.
+modify the `RouterEntry` object from a `Middleware` or `ExceptionHandler`, like the examples below.
 
-The example below will cause the router to re-route the request with the "fake" uri. This does require the `$request` object to be returned, 
-otherwise the `request` object will be ignored by the router.
+#### Faking new route
+
+The example below will cause the router to re-route the request with another url. We are using the `url()` helper function to get the uri to another route added in the `routes.php` file.
+ 
+This does require the `$request` object to be returned, otherwise the `request` object will be ignored by the router.
+
+Using the example below will NOT inherit the rules from the other route. This means that IF you are faking a route that is enabled in `post`.
+
+**NOTE: Use this method if you want to fully load a route (middlewares, request-method etc. will be kept).**
+
 
 ```php
 namespace demo\Middlewares;
@@ -393,7 +400,7 @@ use Pecee\SimpleRouter\RouterEntry;
 class CustomMiddleware implements Middleware {
 
     public function handle(Request $request, RouterEntry &$route = null) {
-        return $request->setUri('/home');
+        return $request->setUri(url('home'));
     }
     
 }
@@ -406,6 +413,8 @@ on some criteria's for the request.
 
 The callback below will fire immediately after the `Middleware` or `ExceptionHandler` has been loaded, as they are loaded before the route is rendered.
 If you wish to change the callback from outside, please have this in mind.
+
+**NOTE: Use this method if you want to load another controller. No additional middlewares or rules will be loaded.**
 
 ```php
 namespace demo\Middlewares;

--- a/README.md
+++ b/README.md
@@ -49,12 +49,17 @@ This is an example of a basic ```index.php``` file:
 ```php
 use \Pecee\SimpleRouter\SimpleRouter;
 
-require_once 'routes.php'; // change this to whatever makes sense in your project
+// Load external routes file
+require_once 'routes.php';
 
-// The apps default namespace (so we don't have to specify it each time we use MyController@home)
+/* 
+ * The default namespace for route-callbacks, so we don't have to specify it each time.
+ * Can be overwritten by using the namespace config option.
+ */
+ 
 SimpleRouter::setDefaultNamespace('MyWebsite\Controller');
 
-// Do the routing
+// Start the routing
 SimpleRouter::start();
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ use \Pecee\SimpleRouter\SimpleRouter;
 require_once 'routes.php'; // change this to whatever makes sense in your project
 
 // The apps default namespace (so we don't have to specify it each time we use MyController@home)
-$defaultControllerNamespace = 'MyWebsite\\Controller';
+SimpleRouter::setDefaultNamespace('MyWebsite\Controller');
 
 // Do the routing
-SimpleRouter::start($defaultControllerNamespace);
+SimpleRouter::start();
 ```
 
 ## Adding routes
@@ -129,6 +129,7 @@ class CustomExceptionHandler implements IExceptionHandler {
 
         // If the error-code is 404; show another route which contains the page-not-found
         if($error->getCode() === 404) {
+        
             // Throw your custom 404-page view
             // - or -
             // load another route with our 404 page
@@ -196,13 +197,16 @@ use Pecee\SimpleRouter\SimpleRouter;
 
 class Router extends SimpleRouter {
 
-    public static function start($defaultNamespace = null) {
+    public static function start() {
 
         // change this to whatever makes sense in your project
         require_once 'routes.php';
+        
+        // change default namespace for all routes
+        parent::setDefaultNamespace('\Demo\Controllers');
 
         // Do initial stuff
-        parent::start('\\Demo\\Controllers');
+        parent::start();
 
     }
 

--- a/demo-project/app/Controllers/ApiController.php
+++ b/demo-project/app/Controllers/ApiController.php
@@ -9,12 +9,10 @@ class ApiController {
 
         // The variable authenticated is set to true in the ApiVerification middleware class.
 
-        $request = SimpleRouter::request();
-
         header('content-type: application/json');
 
         echo json_encode([
-            'authenticated' => $request->authenticated
+            'authenticated' => request()->authenticated
         ]);
 
     }

--- a/demo-project/app/Controllers/DefaultController.php
+++ b/demo-project/app/Controllers/DefaultController.php
@@ -6,7 +6,7 @@ class DefaultController {
     public function index() {
 
         // implement
-        echo 'DefaultController -> index';
+        echo sprintf('DefaultController -> index (?fun=%s)', input()->get('fun'));
 
     }
 

--- a/demo-project/app/Handlers/CustomExceptionHandler.php
+++ b/demo-project/app/Handlers/CustomExceptionHandler.php
@@ -7,7 +7,7 @@ use Pecee\SimpleRouter\RouterEntry;
 
 class CustomExceptionHandler implements IExceptionHandler {
 
-    public function handleError( Request $request, RouterEntry $router = null, \Exception $error) {
+    public function handleError( Request $request, RouterEntry &$route = null, \Exception $error) {
 
         // Return json errors if we encounter an error on /api.
         if(stripos($request->getUri(), '/api') !== false) {

--- a/demo-project/app/Middlewares/ApiVerification.php
+++ b/demo-project/app/Middlewares/ApiVerification.php
@@ -6,7 +6,7 @@ use Pecee\Http\Request;
 
 class ApiVerification implements IMiddleware {
 
-    public function handle(Request $request) {
+    public function handle(Request &$request) {
 
         // Do authentication
         $request->authenticated = true;

--- a/demo-project/app/Middlewares/ApiVerification.php
+++ b/demo-project/app/Middlewares/ApiVerification.php
@@ -3,10 +3,11 @@ namespace Demo\Middlewares;
 
 use Pecee\Http\Middleware\IMiddleware;
 use Pecee\Http\Request;
+use Pecee\SimpleRouter\RouterEntry;
 
 class ApiVerification implements IMiddleware {
 
-    public function handle(Request &$request) {
+    public function handle(Request $request, RouterEntry &$route = null) {
 
         // Do authentication
         $request->authenticated = true;

--- a/demo-project/app/Router.php
+++ b/demo-project/app/Router.php
@@ -19,8 +19,10 @@ class Router extends SimpleRouter {
         // Load our custom routes
         require_once 'routes.php';
 
+        parent::setDefaultNamespace('\Demo\Controllers');
+
         // Do initial stuff
-        parent::start('\\Demo\\Controllers');
+        parent::start();
 
     }
 

--- a/demo-project/app/helpers.php
+++ b/demo-project/app/helpers.php
@@ -1,5 +1,5 @@
 <?php
-use \Pecee\SimpleRouter\SimpleRouter;
+use Pecee\SimpleRouter\SimpleRouter;
 
 function url($controller, $parameters = null, $getParams = null) {
     SimpleRouter::getRoute($controller, $parameters, $getParams);
@@ -28,4 +28,12 @@ function request() {
  */
 function response() {
     return SimpleRouter::response();
+}
+
+/**
+ * Get input class
+ * @return \Pecee\Http\Input\Input
+ */
+function input() {
+    return SimpleRouter::request()->getInput();
 }

--- a/src/Pecee/Exception/RouterException.php
+++ b/src/Pecee/Exception/RouterException.php
@@ -1,3 +1,4 @@
 <?php
 namespace Pecee\Exception;
+
 class RouterException extends \Exception { }

--- a/src/Pecee/Handler/IExceptionHandler.php
+++ b/src/Pecee/Handler/IExceptionHandler.php
@@ -6,6 +6,12 @@ use Pecee\SimpleRouter\RouterEntry;
 
 interface IExceptionHandler {
 
-	public function handleError(Request $request, RouterEntry $router = null, \Exception $error);
+    /**
+     * @param Request $request
+     * @param RouterEntry|null $route
+     * @param \Exception $error
+     * @return Request|null
+     */
+	public function handleError(Request $request, RouterEntry &$route = null, \Exception $error);
 
 }

--- a/src/Pecee/Http/Input/Input.php
+++ b/src/Pecee/Http/Input/Input.php
@@ -25,7 +25,7 @@ class Input {
      */
     protected $request;
 
-    public function __construct(Request &$request) {
+    public function __construct(Request $request) {
         $this->request = $request;
         $this->setGet();
         $this->setPost();

--- a/src/Pecee/Http/Input/InputCollection.php
+++ b/src/Pecee/Http/Input/InputCollection.php
@@ -10,9 +10,10 @@ class InputCollection implements \IteratorAggregate {
      * Useful for searching for finding items where $index doesn't contain form name.
      *
      * @param string $index
+     * @param string|null $defaultValue
      * @return mixed
      */
-    public function findFirst($index) {
+    public function findFirst($index, $defaultValue = null) {
         if(count($this->data)) {
 
             if(isset($this->data[$index])) {
@@ -26,7 +27,7 @@ class InputCollection implements \IteratorAggregate {
             }
         }
 
-        return null;
+        return $defaultValue;
     }
 
     /**

--- a/src/Pecee/Http/Middleware/BaseCsrfVerifier.php
+++ b/src/Pecee/Http/Middleware/BaseCsrfVerifier.php
@@ -4,6 +4,7 @@ namespace Pecee\Http\Middleware;
 use Pecee\CsrfToken;
 use Pecee\Exception\TokenMismatchException;
 use Pecee\Http\Request;
+use Pecee\SimpleRouter\RouterEntry;
 
 class BaseCsrfVerifier implements IMiddleware {
 
@@ -49,11 +50,11 @@ class BaseCsrfVerifier implements IMiddleware {
         return false;
     }
 
-    public function handle(Request $request) {
+    public function handle(Request $request, RouterEntry &$route = null) {
 
-        if($request->getMethod() != 'get' && !$this->skip($request)) {
+        if($request->getMethod() !== 'get' && !$this->skip($request)) {
 
-            $token = (isset($_POST[static::POST_KEY])) ? $_POST[static::POST_KEY] : null;
+            $token = $request->getInput()->post->findFirst(static::POST_KEY);
 
             // If the token is not posted, check headers for valid x-csrf-token
             if($token === null) {

--- a/src/Pecee/Http/Middleware/IMiddleware.php
+++ b/src/Pecee/Http/Middleware/IMiddleware.php
@@ -2,7 +2,15 @@
 namespace Pecee\Http\Middleware;
 
 use Pecee\Http\Request;
+use Pecee\SimpleRouter\RouterEntry;
 
 interface IMiddleware {
-    public function handle(Request $request);
+
+    /**
+     * @param Request $request
+     * @param RouterEntry|null $route
+     * @return Request|null
+     */
+    public function handle(Request $request, RouterEntry &$route = null);
+
 }

--- a/src/Pecee/Http/Response.php
+++ b/src/Pecee/Http/Response.php
@@ -6,7 +6,7 @@ class Response {
 
     protected $request;
 
-    public function __construct(Request &$request) {
+    public function __construct(Request $request) {
         $this->request = $request;
     }
 
@@ -14,7 +14,7 @@ class Response {
      * Set the http status code
      *
      * @param int $code
-     * @return self $this
+     * @return static
      */
     public function httpCode($code) {
         http_response_code($code);
@@ -43,7 +43,7 @@ class Response {
     /**
      * Add http authorisation
      * @param string $name
-     * @return self $this
+     * @return static
      */
     public function auth($name = '') {
         $this->headers([
@@ -87,7 +87,7 @@ class Response {
     /**
      * Add header to response
      * @param string $value
-     * @return self $this
+     * @return static
      */
     public function header($value) {
         header($value);
@@ -97,7 +97,7 @@ class Response {
     /**
      * Add multiple headers to response
      * @param array $headers
-     * @return self $this
+     * @return static
      */
     public function headers(array $headers) {
         foreach($headers as $header) {

--- a/src/Pecee/SimpleRouter/IControllerRoute.php
+++ b/src/Pecee/SimpleRouter/IControllerRoute.php
@@ -1,0 +1,11 @@
+<?php
+namespace Pecee\SimpleRouter;
+
+interface IControllerRoute {
+
+    public function getController();
+    public function setController($controller);
+    public function getMethod();
+    public function setMethod($method);
+
+}

--- a/src/Pecee/SimpleRouter/ILoadableRoute.php
+++ b/src/Pecee/SimpleRouter/ILoadableRoute.php
@@ -1,0 +1,9 @@
+<?php
+namespace Pecee\SimpleRouter;
+
+interface ILoadableRoute {
+
+    public function getUrl();
+    public function setUrl($url);
+
+}

--- a/src/Pecee/SimpleRouter/RouterBase.php
+++ b/src/Pecee/SimpleRouter/RouterBase.php
@@ -106,7 +106,6 @@ class RouterBase {
         $mergedSettings = array();
 
         /* @var $route RouterEntry */
-        /* @var $group RouterGroup */
         for($i = 0; $i < count($routes); $i++) {
 
             $route = $routes[$i];
@@ -148,6 +147,7 @@ class RouterBase {
 
                     if ($route->matchRoute($this->request)) {
 
+                        /* @var $group RouterGroup */
                         $group = $route;
 
                         $mergedSettings = array_merge($settings, $group->getMergeableSettings());
@@ -214,11 +214,11 @@ class RouterBase {
 
                     $routeNotAllowed = false;
 
-                    $this->request->rewrite_uri = $this->request->uri;
+                    $this->request->rewrite_uri = $this->request->getUri();
                     $this->request->setUri($originalUri);
 
                     $this->request->loadedRoute = $route;
-                    $route->loadMiddleware($this->request);
+                    $this->request->loadedRoute->loadMiddleware($this->request);
 
                     $this->request->loadedRoute->renderRoute($this->request);
 

--- a/src/Pecee/SimpleRouter/RouterBase.php
+++ b/src/Pecee/SimpleRouter/RouterBase.php
@@ -77,6 +77,10 @@ class RouterBase {
      */
     protected $loadedRoute;
 
+    /**
+     * List over route changes (to avoid looping)
+     * @var array
+     */
     protected $routeChanges;
 
     public function __construct() {
@@ -233,6 +237,7 @@ class RouterBase {
                     $routeNotAllowed = false;
 
                     $this->loadedRoute = $route;
+
                     $request = $this->loadedRoute->loadMiddleware($request, $this->loadedRoute);
                     $request = ($request === null) ? $this->request : $request;
 
@@ -278,13 +283,15 @@ class RouterBase {
             $request = ($request === null) ? $this->request : $request;
 
             if(!in_array($request->getUri(), $this->routeChanges)) {
+
                 $this->routeChanges[] = $request->getUri();
+
                 if($request->getUri() !== $this->request->getUri()) {
                     $this->routeRequest($request);
                 } else {
-                    $this->routeChanges[] = $request->getUri();
                     $this->loadedRoute->renderRoute($request);
                 }
+
                 return;
             }
 

--- a/src/Pecee/SimpleRouter/RouterBase.php
+++ b/src/Pecee/SimpleRouter/RouterBase.php
@@ -204,13 +204,16 @@ class RouterBase {
                 }
             }
 
-            if($newRequest === null && $this->csrfVerifier !== null) {
+            if($newRequest === null) {
 
                 // Loop through each route-request
                 $this->processRoutes($this->routes);
 
-                // Verify csrf token for request
-                $this->csrfVerifier->handle($this->request);
+                if($this->csrfVerifier !== null) {
+
+                    // Verify csrf token for request
+                    $this->csrfVerifier->handle($this->request);
+                }
             }
 
             $request = ($newRequest !== null) ? $newRequest : $request;

--- a/src/Pecee/SimpleRouter/RouterController.php
+++ b/src/Pecee/SimpleRouter/RouterController.php
@@ -4,7 +4,7 @@ namespace Pecee\SimpleRouter;
 use Pecee\Exception\RouterException;
 use Pecee\Http\Request;
 
-class RouterController extends RouterEntry {
+class RouterController extends RouterEntry implements ILoadableRoute, IControllerRoute {
 
     const DEFAULT_METHOD = 'index';
 
@@ -13,7 +13,6 @@ class RouterController extends RouterEntry {
     protected $method;
 
     public function __construct($url, $controller) {
-        parent::__construct();
         $this->url = $url;
         $this->controller = $controller;
     }
@@ -44,8 +43,8 @@ class RouterController extends RouterEntry {
     }
 
     public function matchRoute(Request $request) {
-        $url = parse_url(urldecode($request->getUri()));
-        $url = rtrim($url['path'], '/') . '/';
+        $url = parse_url(urldecode($request->getUri()), PHP_URL_PATH);
+        $url = rtrim($url, '/') . '/';
 
         if(strtolower($url) == strtolower($this->url) || stripos($url, $this->url) === 0) {
 
@@ -55,11 +54,11 @@ class RouterController extends RouterEntry {
 
             if(count($path)) {
 
-                $method = (!isset($path[0]) || trim($path[0]) === '') ? self::DEFAULT_METHOD : $path[0];
+                $method = (!isset($path[0]) || trim($path[0]) === '') ? static::DEFAULT_METHOD : $path[0];
                 $this->method = $method;
 
                 array_shift($path);
-                $this->parameters = $path;
+                $this->settings['parameters'] = $path;
 
                 // Set callback
                 $this->setCallback($this->controller . '@' . $this->method);

--- a/src/Pecee/SimpleRouter/RouterEntry.php
+++ b/src/Pecee/SimpleRouter/RouterEntry.php
@@ -26,23 +26,10 @@ abstract class RouterEntry {
         'requestMethods' => array(),
         'where' => array(),
         'parameters' => array(),
+        'middleware' => array(),
     ];
 
     protected $callback;
-
-    /**
-     * Returns callback name/identifier for the current route based on the callback.
-     * Useful if you need to get a unique identifier for the loaded route, for instance
-     * when using translations etc.
-     *
-     * @return string
-     */
-    public function getIdentifier() {
-        if(strpos($this->callback, '@') !== false) {
-            return $this->callback;
-        }
-        return 'function_' . md5($this->callback);
-    }
 
     /**
      * @param string $callback
@@ -87,20 +74,11 @@ abstract class RouterEntry {
     }
 
     /**
-     * @param string $prefix
-     * @return static
-     *
-    public function setPrefix($prefix) {
-        $this->settings['prefix'] = '/' . ltrim($prefix, '/');
-        return $this;
-    }*/
-
-    /**
      * @param string $middleware
      * @return static
      */
     public function setMiddleware($middleware) {
-        $this->settings['middleware'] = $middleware;
+        $this->settings['middleware'][] = $middleware;
         return $this;
     }
 

--- a/src/Pecee/SimpleRouter/RouterEntry.php
+++ b/src/Pecee/SimpleRouter/RouterEntry.php
@@ -291,7 +291,7 @@ abstract class RouterEntry {
         return null;
     }
 
-    public function loadMiddleware(Request $request) {
+    public function loadMiddleware(Request $request, RouterRoute &$route) {
         if(count($this->getMiddleware())) {
             foreach($this->getMiddleware() as $middleware) {
                 $middleware = $this->loadClass($middleware);
@@ -300,7 +300,7 @@ abstract class RouterEntry {
                 }
 
                 /* @var $class IMiddleware */
-                $middleware->handle($request);
+                $middleware->handle($request, $route);
             }
         }
     }

--- a/src/Pecee/SimpleRouter/RouterEntry.php
+++ b/src/Pecee/SimpleRouter/RouterEntry.php
@@ -14,23 +14,21 @@ abstract class RouterEntry {
     const REQUEST_TYPE_PATCH = 'patch';
     const REQUEST_TYPE_DELETE = 'delete';
 
-    public static $allowedRequestTypes = array(
+    public static $allowedRequestTypes = [
         self::REQUEST_TYPE_DELETE,
         self::REQUEST_TYPE_GET,
         self::REQUEST_TYPE_POST,
         self::REQUEST_TYPE_PUT,
-        self::REQUEST_TYPE_PATCH
-    );
+        self::REQUEST_TYPE_PATCH,
+    ];
 
-    protected $settings;
+    protected $settings = [
+        'requestMethods' => array(),
+        'where' => array(),
+        'parameters' => array(),
+    ];
+
     protected $callback;
-
-    public function __construct() {
-        $this->settings = array();
-        $this->settings['requestMethods'] = array();
-        $this->settings['where'] = array();
-        $this->settings['parameters'] = array();
-    }
 
     /**
      * Returns callback name/identifier for the current route based on the callback.
@@ -48,7 +46,7 @@ abstract class RouterEntry {
 
     /**
      * @param string $callback
-     * @return self;
+     * @return static
      */
     public function setCallback($callback) {
         $this->callback = $callback;
@@ -90,50 +88,43 @@ abstract class RouterEntry {
 
     /**
      * @param string $prefix
-     * @return self
-     */
+     * @return static
+     *
     public function setPrefix($prefix) {
-        $this->prefix = '/' . ltrim($prefix, '/');
+        $this->settings['prefix'] = '/' . ltrim($prefix, '/');
         return $this;
-    }
+    }*/
 
     /**
      * @param string $middleware
-     * @return self
+     * @return static
      */
     public function setMiddleware($middleware) {
-        $this->middleware = $middleware;
+        $this->settings['middleware'] = $middleware;
         return $this;
     }
 
     /**
      * @param string $namespace
-     * @return self
+     * @return static
      */
     public function setNamespace($namespace) {
-        $this->namespace = $namespace;
+        $this->settings['namespace'] = $namespace;
         return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getPrefix() {
-        return $this->prefix;
     }
 
     /**
      * @return string|array
      */
     public function getMiddleware() {
-        return $this->middleware;
+        return $this->settingArray('middleware');
     }
 
     /**
      * @return string
      */
     public function getNamespace() {
-        return $this->namespace;
+        return $this->setting('namespace');
     }
 
     /**
@@ -144,18 +135,18 @@ abstract class RouterEntry {
     }
 
     /**
-     * @return mixed
+     * @return array
      */
     public function getParameters(){
-        return ($this->parameters === null) ? array() : $this->parameters;
+        return $this->setting('parameters', array());
     }
 
     /**
      * @param mixed $parameters
-     * @return self
+     * @return static
      */
     public function setParameters($parameters) {
-        $this->parameters = $parameters;
+        $this->settings['parameters'] = $parameters;
         return $this;
     }
 
@@ -163,10 +154,10 @@ abstract class RouterEntry {
      * Add regular expression parameter match
      *
      * @param array $options
-     * @return self
+     * @return static
      */
     public function where(array $options) {
-        $this->where = array_merge($this->where, $options);
+        $this->settings['where'] = array_merge($this->settings['where'], $options);
         return $this;
     }
 
@@ -174,10 +165,10 @@ abstract class RouterEntry {
      * Add regular expression match for url
      *
      * @param string $regex
-     * @return self
+     * @return static
      */
     public function match($regex) {
-        $this->regexMatch = $regex;
+        $this->settings['regexMatch'] = $regex;
         return $this;
     }
 
@@ -187,58 +178,25 @@ abstract class RouterEntry {
      * @return array
      */
     public function getMergeableSettings() {
-        $settings = $this->settings;
-
-        if(isset($settings['prefix'])) {
-            unset($settings['prefix']);
-        }
-
-        return $settings;
+        return $this->settings;
     }
 
     /**
      * @param array $settings
-     * @return self
+     * @return static
      */
-    public function addSettings(array $settings = null) {
-        if(is_array($settings)) {
-            $this->settings = array_merge($this->settings, $settings);
-        }
+    public function addSettings(array $settings) {
+        $this->settings = array_merge($this->settings, $settings);
         return $this;
     }
 
     /**
      * @param array $settings
-     * @return self
+     * @return static
      */
     public function setSettings($settings) {
         $this->settings = $settings;
-
-        if(isset($settings['prefix'])) {
-            $this->setPrefix($settings['prefix']);
-        }
-
         return $this;
-    }
-
-    /**
-     * Dynamically access settings value
-     *
-     * @param $name
-     * @return mixed|null
-     */
-    public function __get($name) {
-        return (isset($this->settings[$name]) ? $this->settings[$name] : null);
-    }
-
-    /**
-     * Dynamically set settings value
-     *
-     * @param string $name
-     * @param mixed|null $value
-     */
-    public function __set($name, $value = null) {
-        $this->settings[$name] = $value;
     }
 
     protected function loadClass($name) {
@@ -273,8 +231,8 @@ abstract class RouterEntry {
                 // Check for optional parameter
 
                 // Use custom parameter regex if it exists
-                if(is_array($this->where) && isset($this->where[$parameter])) {
-                    $parameterRegex = $this->where[$parameter];
+                if(is_array($this->setting('where')) && isset($this->settings['where'][$parameter])) {
+                    $parameterRegex = $this->settings['where'][$parameter];
                 }
 
                 if($lastCharacter === '?') {
@@ -284,7 +242,12 @@ abstract class RouterEntry {
                 } else {
                     $regex .= '\/?(?P<' . $parameter . '>'. $parameterRegex .')[^\/]?';
                 }
-                $parameterNames[] = array('name' => $parameter, 'required' => $required);
+
+                $parameterNames[] = [
+                    'name' => $parameter,
+                    'required' => $required
+                ];
+
                 $parameter = '';
                 $isParameter = false;
 
@@ -307,21 +270,19 @@ abstract class RouterEntry {
 
             $max = count($parameterNames);
 
-            if($max) {
-                for($i = 0; $i < $max; $i++) {
-                    $name = $parameterNames[$i];
-                    $parameterValue = isset($parameterValues[$name['name']]) ? $parameterValues[$name['name']] : null;
+            for($i = 0; $i < $max; $i++) {
+                $name = $parameterNames[$i];
+                $parameterValue = isset($parameterValues[$name['name']]) ? $parameterValues[$name['name']] : null;
 
-                    if($name['required'] && $parameterValue === null) {
-                        throw new RouterException('Missing required parameter ' . $name['name'], 404);
-                    }
-
-                    if(!$name['required'] && $parameterValue === null) {
-                        continue;
-                    }
-
-                    $parameters[$name['name']] = $parameterValue;
+                if($name['required'] && $parameterValue === null) {
+                    throw new RouterException('Missing required parameter ' . $name['name'], 404);
                 }
+
+                if(!$name['required'] && $parameterValue === null) {
+                    continue;
+                }
+
+                $parameters[$name['name']] = $parameterValue;
             }
 
             return $parameters;
@@ -331,21 +292,11 @@ abstract class RouterEntry {
     }
 
     public function loadMiddleware(Request $request) {
-        if($this->getMiddleware()) {
-            if(is_array($this->getMiddleware())) {
-                foreach($this->getMiddleware() as $middleware) {
-                    $middleware = $this->loadClass($middleware);
-                    if (!($middleware instanceof IMiddleware)) {
-                        throw new RouterException($middleware . ' must be instance of Middleware');
-                    }
-
-                    /* @var $class IMiddleware */
-                    $middleware->handle($request);
-                }
-            } else {
-                $middleware = $this->loadClass($this->getMiddleware());
+        if(count($this->getMiddleware())) {
+            foreach($this->getMiddleware() as $middleware) {
+                $middleware = $this->loadClass($middleware);
                 if (!($middleware instanceof IMiddleware)) {
-                    throw new RouterException($this->getMiddleware() . ' must be instance of Middleware');
+                    throw new RouterException($middleware . ' must be instance of Middleware');
                 }
 
                 /* @var $class IMiddleware */
@@ -371,7 +322,7 @@ abstract class RouterEntry {
             }
 
             $parameters = array_filter($this->getParameters(), function($var){
-                return !is_null($var);
+                return ($var !== null);
             });
 
             call_user_func_array(array($class, $method), $parameters);
@@ -386,7 +337,7 @@ abstract class RouterEntry {
      * Set allowed request methods
      *
      * @param array $methods
-     * @return self $this
+     * @return static $this
      */
     public function setRequestMethods(array $methods) {
         $this->settings['requestMethods'] = $methods;
@@ -399,20 +350,30 @@ abstract class RouterEntry {
      * @return array
      */
     public function getRequestMethods() {
-        if(!isset($this->settings['requestMethods']) || isset($this->settings['requestMethods']) && !is_array($this->settings['requestMethods'])) {
-            $value = isset($this->settings['requestMethods']) ? $this->settings['requestMethods'] : null;
-            return array($value);
-        }
-        return $this->settings['requestMethods'];
+        return $this->settingArray('requestMethods');
     }
 
     public function getGroup() {
-        return $this->group;
+        return $this->setting('group');
     }
 
     public function setGroup($group) {
-        $this->group = $group;
+        $this->settings['group'] = $group;
         return $this;
+    }
+
+    protected function setting($name, $defaultValue = null) {
+        return isset($this->settings[$name]) ? $this->settings[$name] : $defaultValue;
+    }
+
+    protected function settingArray($name) {
+        $value = $this->setting($name);
+
+        if($value === null) {
+            return [];
+        }
+
+        return (!is_array($value)) ? array($value) : $value;
     }
 
     abstract function matchRoute(Request $request);

--- a/src/Pecee/SimpleRouter/RouterGroup.php
+++ b/src/Pecee/SimpleRouter/RouterGroup.php
@@ -113,8 +113,8 @@ class RouterGroup extends RouterEntry {
         // Push middleware if multiple
         if ($this->getMiddleware() !== null && isset($settings['middleware'])) {
 
-            if (!is_array($this->getMiddleware())) {
-                $settings['middleware'] = array($this->getMiddleware(), $settings['middleware']);
+            if (!is_array($settings['middleware'])) {
+                $settings['middleware'] = array_merge($this->getMiddleware(), array($settings['middleware']));
             } else {
                 $settings['middleware'][] = $this->getMiddleware();
             }

--- a/src/Pecee/SimpleRouter/RouterGroup.php
+++ b/src/Pecee/SimpleRouter/RouterGroup.php
@@ -7,8 +7,6 @@ use Pecee\Http\Request;
 
 class RouterGroup extends RouterEntry {
 
-    protected $loadableRoute = false;
-
     public function matchDomain(Request $request) {
         if($this->setting('domain') !== null) {
 

--- a/src/Pecee/SimpleRouter/RouterResource.php
+++ b/src/Pecee/SimpleRouter/RouterResource.php
@@ -4,17 +4,16 @@ namespace Pecee\SimpleRouter;
 use Pecee\Exception\RouterException;
 use Pecee\Http\Request;
 
-class RouterResource extends RouterEntry {
+class RouterResource extends RouterEntry implements ILoadableRoute, IControllerRoute {
 
     protected $url;
     protected $controller;
     protected $postMethod;
 
     public function __construct($url, $controller) {
-        parent::__construct();
         $this->url = $url;
         $this->controller = $controller;
-        $this->postMethod = strtolower(($_SERVER['REQUEST_METHOD'] != 'GET') ? 'post' : 'get');
+        $this->postMethod = strtolower(($_SERVER['REQUEST_METHOD']) !== 'get') ? 'post' : 'get';
     }
 
     public function renderRoute(Request $request) {
@@ -42,7 +41,7 @@ class RouterResource extends RouterEntry {
 
     protected function call($method, $parameters) {
         $this->setCallback($this->controller . '@' . $method);
-        $this->parameters = $parameters;
+        $this->settings['parameters'] = $parameters;
         return true;
     }
 
@@ -57,39 +56,39 @@ class RouterResource extends RouterEntry {
         if($parameters !== null) {
 
             if(is_array($parameters)) {
-                $parameters = array_merge($this->parameters, $parameters);
+                $parameters = array_merge($this->settings['parameters'], $parameters);
             }
 
             $action = isset($parameters['action']) ? $parameters['action'] : null;
             unset($parameters['action']);
 
             // Delete
-            if($request->getMethod() === self::REQUEST_TYPE_DELETE && $this->postMethod === self::REQUEST_TYPE_POST) {
+            if($request->getMethod() === static::REQUEST_TYPE_DELETE && $this->postMethod === static::REQUEST_TYPE_POST) {
                 return $this->call('destroy', $parameters);
             }
 
             // Update
-            if(in_array($request->getMethod(), array(self::REQUEST_TYPE_PATCH, self::REQUEST_TYPE_PUT)) && $this->postMethod === self::REQUEST_TYPE_POST) {
+            if(in_array($request->getMethod(), array(static::REQUEST_TYPE_PATCH, static::REQUEST_TYPE_PUT)) && $this->postMethod === static::REQUEST_TYPE_POST) {
                 return $this->call('update', $parameters);
             }
 
             // Edit
-            if(isset($action) && strtolower($action) === 'edit' && $this->postMethod === self::REQUEST_TYPE_GET) {
+            if(isset($action) && strtolower($action) === 'edit' && $this->postMethod === static::REQUEST_TYPE_GET) {
                 return $this->call('edit', $parameters);
             }
 
             // Create
-            if(strtolower($action) === 'create' && $request->getMethod() === self::REQUEST_TYPE_GET) {
+            if(strtolower($action) === 'create' && $request->getMethod() === static::REQUEST_TYPE_GET) {
                 return $this->call('create', $parameters);
             }
 
             // Save
-            if($this->postMethod === self::REQUEST_TYPE_POST) {
+            if($this->postMethod === static::REQUEST_TYPE_POST) {
                 return $this->call('store', $parameters);
             }
 
             // Show
-            if(isset($parameters['id']) && $this->postMethod === self::REQUEST_TYPE_GET) {
+            if(isset($parameters['id']) && $this->postMethod === static::REQUEST_TYPE_GET) {
                 return $this->call('show', $parameters);
             }
 

--- a/src/Pecee/SimpleRouter/RouterResource.php
+++ b/src/Pecee/SimpleRouter/RouterResource.php
@@ -8,12 +8,10 @@ class RouterResource extends RouterEntry implements ILoadableRoute, IControllerR
 
     protected $url;
     protected $controller;
-    protected $postMethod;
 
     public function __construct($url, $controller) {
         $this->url = $url;
         $this->controller = $controller;
-        $this->postMethod = strtolower(($_SERVER['REQUEST_METHOD']) !== 'get') ? 'post' : 'get';
     }
 
     public function renderRoute(Request $request) {
@@ -46,8 +44,8 @@ class RouterResource extends RouterEntry implements ILoadableRoute, IControllerR
     }
 
     public function matchRoute(Request $request) {
-        $url = parse_url(urldecode($request->getUri()));
-        $url = rtrim($url['path'], '/') . '/';
+        $url = parse_url(urldecode($request->getUri()), PHP_URL_PATH);
+        $url = rtrim($url, '/') . '/';
 
         $route = rtrim($this->url, '/') . '/{id?}/{action?}';
 
@@ -63,17 +61,17 @@ class RouterResource extends RouterEntry implements ILoadableRoute, IControllerR
             unset($parameters['action']);
 
             // Delete
-            if($request->getMethod() === static::REQUEST_TYPE_DELETE && $this->postMethod === static::REQUEST_TYPE_POST) {
+            if($request->getMethod() === static::REQUEST_TYPE_DELETE && $request->getMethod() === static::REQUEST_TYPE_POST) {
                 return $this->call('destroy', $parameters);
             }
 
             // Update
-            if(in_array($request->getMethod(), array(static::REQUEST_TYPE_PATCH, static::REQUEST_TYPE_PUT)) && $this->postMethod === static::REQUEST_TYPE_POST) {
+            if(in_array($request->getMethod(), array(static::REQUEST_TYPE_PATCH, static::REQUEST_TYPE_PUT)) && $request->getMethod() === static::REQUEST_TYPE_POST) {
                 return $this->call('update', $parameters);
             }
 
             // Edit
-            if(isset($action) && strtolower($action) === 'edit' && $this->postMethod === static::REQUEST_TYPE_GET) {
+            if(isset($action) && strtolower($action) === 'edit' && $request->getMethod() === static::REQUEST_TYPE_GET) {
                 return $this->call('edit', $parameters);
             }
 
@@ -83,12 +81,12 @@ class RouterResource extends RouterEntry implements ILoadableRoute, IControllerR
             }
 
             // Save
-            if($this->postMethod === static::REQUEST_TYPE_POST) {
+            if($request->getMethod() === static::REQUEST_TYPE_POST) {
                 return $this->call('store', $parameters);
             }
 
             // Show
-            if(isset($parameters['id']) && $this->postMethod === static::REQUEST_TYPE_GET) {
+            if(isset($parameters['id']) && $request->getMethod() === static::REQUEST_TYPE_GET) {
                 return $this->call('show', $parameters);
             }
 
@@ -111,8 +109,7 @@ class RouterResource extends RouterEntry implements ILoadableRoute, IControllerR
      * @return static
      */
     public function setUrl($url) {
-        $url = rtrim($url, '/') . '/';
-        $this->url = $url;
+        $this->url = rtrim($url, '/') . '/';
         return $this;
     }
 

--- a/src/Pecee/SimpleRouter/SimpleRouter.php
+++ b/src/Pecee/SimpleRouter/SimpleRouter.php
@@ -15,11 +15,18 @@ class SimpleRouter {
 
     /**
      * Start/route request
-     * @param null $defaultNamespace
      * @throws \Pecee\Exception\RouterException
      */
-    public static function start($defaultNamespace = null) {
-        RouterBase::getInstance()->setDefaultNamespace($defaultNamespace)->routeRequest();
+    public static function start() {
+        RouterBase::getInstance()->routeRequest();
+    }
+
+    /**
+     * Set default namespace for all routes
+     * @param string $defaultNamespace
+     */
+    public static function setDefaultNamespace($defaultNamespace) {
+        RouterBase::getInstance()->setDefaultNamespace($defaultNamespace);
     }
 
     /**
@@ -27,7 +34,7 @@ class SimpleRouter {
      * @param BaseCsrfVerifier $baseCsrfVerifier
      */
     public static function csrfVerifier(BaseCsrfVerifier $baseCsrfVerifier) {
-        RouterBase::getInstance()->setBaseCsrfVerifier($baseCsrfVerifier);
+        RouterBase::getInstance()->setCsrfVerifier($baseCsrfVerifier);
     }
 
     public static function addBootManager(RouterBootManager $bootManager) {
@@ -35,19 +42,19 @@ class SimpleRouter {
     }
 
     public static function get($url, $callback, array $settings = null) {
-        return self::match(['get'], $url, $callback, $settings);
+        return static::match(['get'], $url, $callback, $settings);
     }
 
     public static function post($url, $callback, array $settings = null) {
-        return self::match(['post'], $url, $callback, $settings);
+        return static::match(['post'], $url, $callback, $settings);
     }
 
     public static function put($url, $callback, array $settings = null) {
-        return self::match(['put'], $url, $callback, $settings);
+        return static::match(['put'], $url, $callback, $settings);
     }
 
     public static function delete($url, $callback, array $settings = null) {
-        return self::match(['delete'], $url, $callback, $settings);
+        return static::match(['delete'], $url, $callback, $settings);
     }
 
     public static function group($settings = array(), $callback) {
@@ -72,7 +79,7 @@ class SimpleRouter {
      * @return RouterRoute
      */
     public static function basic($url, $callback, array $settings = null) {
-        return self::match(['get', 'post'], $url, $callback, $settings);
+        return static::match(['get', 'post'], $url, $callback, $settings);
     }
 
     public static function match(array $requestMethods, $url, $callback, array $settings = null) {
@@ -119,21 +126,25 @@ class SimpleRouter {
             $route->addSettings($settings);
         }
 
-        RouterBase::getInstance()->addRoute($route);
+        static::router()->addRoute($route);
 
         return $route;
     }
 
     public static function getRoute($controller = null, $parameters = null, $getParams = null) {
-        return RouterBase::getInstance()->getRoute($controller, $parameters, $getParams);
+        return static::router()->getRoute($controller, $parameters, $getParams);
     }
 
     public static function request() {
-        return RouterBase::getInstance()->getRequest();
+        return static::router()->getRequest();
     }
 
     public static function response() {
-        return RouterBase::getInstance()->getResponse();
+        return static::router()->getResponse();
+    }
+
+    protected static function router() {
+        return RouterBase::getInstance();
     }
 
 }

--- a/test/Dummy/DummyMiddleware.php
+++ b/test/Dummy/DummyMiddleware.php
@@ -7,7 +7,7 @@ use Pecee\Http\Request;
 
 class DummyMiddleware implements IMiddleware {
 
-    public function handle(Request $request) {
+    public function handle(Request $request, \Pecee\SimpleRouter\RouterEntry &$route = null) {
        throw new MiddlewareLoadedException('Middleware loaded!');
     }
 

--- a/test/Dummy/Handler/ExceptionHandler.php
+++ b/test/Dummy/Handler/ExceptionHandler.php
@@ -1,7 +1,7 @@
 <?php
 class ExceptionHandler implements \Pecee\Handler\IExceptionHandler {
 
-    public function handleError(\Pecee\Http\Request $request, \Pecee\SimpleRouter\RouterEntry $router = null, \Exception $error){
+    public function handleError(\Pecee\Http\Request $request, \Pecee\SimpleRouter\RouterEntry &$route = null, \Exception $error){
         throw $error;
     }
 

--- a/test/GroupTest.php
+++ b/test/GroupTest.php
@@ -7,7 +7,7 @@ class GroupTest extends PHPUnit_Framework_TestCase  {
 
     protected $result;
 
-    public function testGroup() {
+    public function testGroupLoad() {
 
         $this->result = false;
 
@@ -18,7 +18,7 @@ class GroupTest extends PHPUnit_Framework_TestCase  {
         try {
             \Pecee\SimpleRouter\SimpleRouter::start();
         } catch(Exception $e) {
-
+            echo $e->getMessage();
         }
 
         $this->assertTrue($this->result);

--- a/test/GroupTest.php
+++ b/test/GroupTest.php
@@ -7,15 +7,13 @@ class GroupTest extends PHPUnit_Framework_TestCase  {
 
     protected $result;
 
-    protected function group() {
-        $this->result = true;
-    }
-
     public function testGroup() {
 
         $this->result = false;
 
-        \Pecee\SimpleRouter\SimpleRouter::group(['prefix' => '/group'], $this->group());
+        \Pecee\SimpleRouter\SimpleRouter::group(['prefix' => '/group'], function() {
+            $this->result = true;
+        });
 
         try {
             \Pecee\SimpleRouter\SimpleRouter::start();
@@ -39,6 +37,41 @@ class GroupTest extends PHPUnit_Framework_TestCase  {
         });
 
         \Pecee\SimpleRouter\SimpleRouter::start();
+    }
+
+    public function testManyRoutes() {
+
+        \Pecee\SimpleRouter\RouterBase::getInstance()->reset();
+        \Pecee\SimpleRouter\SimpleRouter::request()->setUri('/my/match');
+        \Pecee\SimpleRouter\SimpleRouter::request()->setMethod('get');
+
+        \Pecee\SimpleRouter\SimpleRouter::group(['prefix' => '/api'], function() {
+            \Pecee\SimpleRouter\SimpleRouter::group(['prefix' => '/v1'], function() {
+                \Pecee\SimpleRouter\SimpleRouter::get('/test', 'DummyController@start');
+            });
+        });
+
+        \Pecee\SimpleRouter\SimpleRouter::get('/my/match', 'DummyController@start');
+
+        \Pecee\SimpleRouter\SimpleRouter::group(['prefix' => '/service'], function() {
+            \Pecee\SimpleRouter\SimpleRouter::group(['prefix' => '/v1'], function() {
+                \Pecee\SimpleRouter\SimpleRouter::get('/no-match', 'DummyController@start');
+            });
+        });
+
+        \Pecee\SimpleRouter\SimpleRouter::start();
+    }
+
+    public function testUrls() {
+
+        \Pecee\SimpleRouter\SimpleRouter::get('/my/fancy/url/1', 'DummyController@start', ['as' => 'fancy1']);
+        \Pecee\SimpleRouter\SimpleRouter::get('/my/fancy/url/2', 'DummyController@start')->setAlias('fancy2');
+
+        \Pecee\SimpleRouter\SimpleRouter::start();
+
+        $this->assertTrue((\Pecee\SimpleRouter\SimpleRouter::getRoute('fancy1') === '/my/fancy/url/1/'));
+        $this->assertTrue((\Pecee\SimpleRouter\SimpleRouter::getRoute('fancy2') === '/my/fancy/url/2/'));
+
     }
 
 }


### PR DESCRIPTION
- Removed `defaultNamespace` variable from `SimpleRouter::start()` and moved it to separate static method called `setDefaultNamespace($namespace)`.
- `IExceptionHandler` interface now takes `$route` parameter as reference.
- Added `$route` parameter to `IMiddleware` interface.
- Added `IControllerRoute` and `ILoadableRoute` interfaces to easier group roues.
- Fixed `as` not working when using alias in option array.  
- Major refactor of the `Request` class.
- Refactored Route classes - removed magic-method to enhance speed (it does come at a cost of a little more code).
- Added proper documentation for changing route (using fake route) and altering the callback and fixed some issues in regards to this.
- Renamed `setBaseCsrfVerifier` and `getBaseCsrfVerifier` methods in `RouterBase` to `getCsrfVerifier` and `setCsrfVerifier`.
- Changed `self` constants to `static` so they can be extended in the future.
- Added nested groups and alias unit-tests. 
- Updated demo-project to reflect latest changes.
- Updated documentation to reflect latest changes.
- Optimisation enhancements and bugfixes.

## Release notes

Please note that this is a somewhat big refactoring of simple-php-router. Please read the changelog carefully and use it in your development-environment - before deploying it in production, as there might be braking changes.

1. If using custom namespace and/or `Router` - set your default namespace by calling the `SimpleRouter::router()->setDefaultNamespace($namespace)` method.

2. Please update all classes implementing `IExceptionHandler` with new updated properties.

3. Please update all classes implementing `IMiddleware` with new updated properties.