### PR TITLE
Development

### DIFF
--- a/demo-project/composer.json
+++ b/demo-project/composer.json
@@ -10,7 +10,7 @@
 	"type": "project",
 	"require": {
 		"php": ">=5.4.0",
-		"pecee/simple-router": "1.*"
+		"pecee/simple-router": "2.*"
 	},
 	"require-dev": {
 

--- a/src/Pecee/SimpleRouter/LoadableRoute.php
+++ b/src/Pecee/SimpleRouter/LoadableRoute.php
@@ -19,25 +19,7 @@ abstract class LoadableRoute extends RouterEntry implements ILoadableRoute {
      * @return static
      */
     public function setUrl($url) {
-
         $this->url = '/' . trim($url, '/') . '/';
-        /*$this->originalUrl = $this->url;
-
-        if(preg_match_all('/' . static::PARAMETERS_REGEX_MATCH . '/is', $this->url, $matches)) {
-            $parameters = $matches[1];
-
-
-            if (count($parameters)) {
-
-                foreach (array_keys($parameters) as $key) {
-                    $parameters[$key] = null;
-                }
-
-                $this->settings['parameters'] = $parameters;
-            }
-
-        }*/
-
         return $this;
     }
 

--- a/src/Pecee/SimpleRouter/LoadableRoute.php
+++ b/src/Pecee/SimpleRouter/LoadableRoute.php
@@ -1,0 +1,93 @@
+<?php
+namespace Pecee\SimpleRouter;
+
+abstract class LoadableRoute extends RouterEntry implements ILoadableRoute {
+
+    const PARAMETERS_REGEX_MATCH = '{([A-Za-z\-\_]*?)\?{0,1}}';
+
+    protected $url;
+
+    public function getUrl() {
+        return $this->url;
+    }
+
+    /**
+     * Set url
+     *
+     * @param string $url
+     * @return static
+     */
+    public function setUrl($url) {
+
+        $this->url = '/' . trim($url, '/') . '/';
+        /*$this->originalUrl = $this->url;
+
+        if(preg_match_all('/' . static::PARAMETERS_REGEX_MATCH . '/is', $this->url, $matches)) {
+            $parameters = $matches[1];
+
+
+            if (count($parameters)) {
+
+                foreach (array_keys($parameters) as $key) {
+                    $parameters[$key] = null;
+                }
+
+                $this->settings['parameters'] = $parameters;
+            }
+
+        }*/
+
+        return $this;
+    }
+
+    /**
+     * Get alias for the url which can be used when getting the url route.
+     * @return string|array
+     */
+    public function getAlias(){
+        return $this->getSetting('alias');
+    }
+
+    /**
+     * Check if route has given alias.
+     *
+     * @param string $name
+     * @return bool
+     */
+    public function hasAlias($name) {
+        if ($this->getAlias() !== null) {
+            if (is_array($this->getAlias())) {
+                foreach ($this->getAlias() as $alias) {
+                    if (strtolower($alias) === strtolower($name)) {
+                        return true;
+                    }
+                }
+            }
+            return strtolower($this->getAlias()) === strtolower($name);
+        }
+
+        return false;
+    }
+
+    /**
+     * Set the url alias for easier getting the url route.
+     * @param string|array $alias
+     * @return static
+     */
+    public function setAlias($alias){
+        $this->settings['alias'] = $alias;
+        return $this;
+    }
+
+    public function addSettings(array $settings) {
+
+        // Change as to alias
+        if(isset($settings['as'])) {
+            $this->setAlias($settings['as']);
+            unset($settings['as']);
+        }
+
+        return parent::addSettings($settings);
+    }
+
+}

--- a/src/Pecee/SimpleRouter/LoadableRoute.php
+++ b/src/Pecee/SimpleRouter/LoadableRoute.php
@@ -6,6 +6,7 @@ abstract class LoadableRoute extends RouterEntry implements ILoadableRoute {
     const PARAMETERS_REGEX_MATCH = '{([A-Za-z\-\_]*?)\?{0,1}}';
 
     protected $url;
+    protected $alias;
 
     public function getUrl() {
         return $this->url;
@@ -45,7 +46,7 @@ abstract class LoadableRoute extends RouterEntry implements ILoadableRoute {
      * @return string|array
      */
     public function getAlias(){
-        return $this->getSetting('alias');
+        return $this->alias;
     }
 
     /**
@@ -75,19 +76,18 @@ abstract class LoadableRoute extends RouterEntry implements ILoadableRoute {
      * @return static
      */
     public function setAlias($alias){
-        $this->settings['alias'] = $alias;
+        $this->alias = $alias;
         return $this;
     }
 
-    public function addSettings(array $settings) {
+    public function setData(array $settings) {
 
         // Change as to alias
         if(isset($settings['as'])) {
             $this->setAlias($settings['as']);
-            unset($settings['as']);
         }
 
-        return parent::addSettings($settings);
+        return parent::setData($settings);
     }
 
 }

--- a/src/Pecee/SimpleRouter/RouterBase.php
+++ b/src/Pecee/SimpleRouter/RouterBase.php
@@ -24,10 +24,11 @@ class RouterBase {
     protected $response;
 
     /**
-     * Used to keep track of whether to add routes to stack or not.
-     * @var RouterEntry
+     * Used to keep track of whether or not a should should be added to
+     * the backstack-list for group-processing or not.
+     * @var bool
      */
-    protected $currentRoute;
+    protected $processingRoute;
 
     /**
      * All added routes
@@ -78,24 +79,25 @@ class RouterBase {
     protected $loadedRoute;
 
     /**
-     * List over route changes (to avoid looping)
+     * List over route changes (to avoid endless-looping)
      * @var array
      */
-    protected $routeChanges;
+    protected $routeChanges = array();
 
     public function __construct() {
+
         $this->reset();
     }
 
     public function reset() {
+        $this->processingRoute = false;
         $this->request = new Request();
         $this->response = new Response($this->request);
         $this->routes = array();
+        $this->bootManagers = array();
         $this->backStack = array();
         $this->controllerUrlMap = array();
-        $this->bootManagers = array();
         $this->exceptionHandlers = array();
-        $this->routeChanges = array();
     }
 
     /**
@@ -104,7 +106,7 @@ class RouterBase {
      * @return RouterEntry
      */
     public function addRoute(RouterEntry $route) {
-        if($this->currentRoute !== null) {
+        if($this->processingRoute) {
             $this->backStack[] = $route;
         } else {
             $this->routes[] = $route;
@@ -113,7 +115,7 @@ class RouterBase {
         return $route;
     }
 
-    protected function processRoutes(array $routes, array $settings = array(), array $prefixes = array(), $backStack = false, RouterGroup $group = null) {
+    protected function processRoutes(array $routes, array $settings = array(), array $prefixes = array(), RouterEntry $parent = null) {
         // Loop through each route-request
 
         $mergedSettings = array();
@@ -127,11 +129,24 @@ class RouterBase {
                 $route->addSettings($settings);
             }
 
-            if($backStack && $group !== null) {
-                $route->setGroup($group);
-            } else {
-                $prefixes = [];
-                $group = null;
+            if($parent !== null) {
+
+                if($parent instanceof RouterGroup) {
+                    if ($parent->getPrefix() !== null && trim($parent->getPrefix(), '/') !== '') {
+                        $prefixes[] = trim($parent->getPrefix(), '/');
+                    }
+
+                    if ($route->matchRoute($this->request)) {
+                        $mergedSettings = array_merge($settings, $parent->getMergeableSettings());
+
+                        // Add ExceptionHandler
+                        if (count($parent->getExceptionHandlers())) {
+                            $this->exceptionHandlers = array_merge($this->exceptionHandlers, $parent->getExceptionHandler());
+                        }
+                    }
+                }
+
+                $route->setParent($parent);
             }
 
             if($route->getNamespace() === null && $this->defaultNamespace !== null) {
@@ -143,52 +158,26 @@ class RouterBase {
                 $route->setNamespace($namespace);
             }
 
-            $this->currentRoute = $route;
-
             if($route instanceof ILoadableRoute) {
-                if(is_array($prefixes) && count($prefixes) && $backStack) {
-                    $route->setUrl( '/' . join('/', $prefixes) . $route->getUrl() );
-                }
-
+                $route->setUrl( trim(join('/', $prefixes) . $route->getUrl(), '/') );
                 $this->controllerUrlMap[] = $route;
             } else {
-
-                if($route instanceof RouterGroup) {
-
-                    if ($route->getPrefix() !== null && trim($route->getPrefix(), '/') !== '') {
-                        $prefixes[] = trim($route->getPrefix(), '/');
-                    }
-
-                    if (is_callable($route->getCallback())) {
-
-                        $route->renderRoute($this->request);
-
-                        if ($route->matchRoute($this->request)) {
-
-                            /* @var $group RouterGroup */
-                            $group = $route;
-
-                            $mergedSettings = array_merge($settings, $group->getMergeableSettings());
-
-                            // Add ExceptionHandler
-                            if ($group->getExceptionHandler() !== null) {
-                                $this->exceptionHandlers[] = $route;
-                            }
-
-                        }
-                    }
+                if ($route->getCallback() !== null && is_callable($route->getCallback())) {
+                    $this->processingRoute = true;
+                    $route->renderRoute($this->request);
+                    $this->processingRoute = false;
                 }
             }
-
-            $this->currentRoute = null;
 
             if(count($this->backStack)) {
                 $backStack = $this->backStack;
                 $this->backStack = array();
 
                 // Route any routes added to the backstack
-                $this->processRoutes($backStack, $mergedSettings, $prefixes, true, $group);
+                $this->processRoutes($backStack, $mergedSettings, $prefixes, $route);
             }
+
+            $prefixes = [];
         }
     }
 
@@ -269,9 +258,8 @@ class RouterBase {
 
     protected function handleException(\Exception $e) {
 
-        /* @var $route RouterGroup */
-        foreach ($this->exceptionHandlers as $route) {
-            $handler = $route->getExceptionHandler();
+        /* @var $handler IExceptionHandler */
+        foreach ($this->exceptionHandlers as $handler) {
             $handler = new $handler();
 
             if (!($handler instanceof IExceptionHandler)) {
@@ -394,12 +382,14 @@ class RouterBase {
 
         $domain = '';
 
-        if($route->getGroup() !== null && $route->getGroup()->getDomain() !== null) {
-            if(is_array($route->getGroup()->getDomain())) {
-                $domains = $route->getGroup()->getDomain();
+        $parent = $route->getParent();
+
+        if($parent !== null && ($parent instanceof RouterGroup) && $parent->getDomain() !== null) {
+            if(is_array($parent->getDomain())) {
+                $domains = $parent->getDomain();
                 $domain = array_shift($domains);
             } else {
-                $domain = $route->getGroup()->getDomain();
+                $domain = $parent->getDomain();
             }
 
             $domain = '//' . $domain;
@@ -482,16 +472,25 @@ class RouterBase {
             $route = $this->controllerUrlMap[$i];
 
             // Check an alias exist, if the matches - use it
-            if($route instanceof IControllerRoute) {
-                $c = $route->getController();
-            } else {
-                if($route->hasAlias($controller)) {
+            if($route instanceof LoadableRoute) {
+
+                // Check for alias
+                if ($route->hasAlias($controller)) {
                     return $this->processUrl($route, $route->getMethod(), $parameters, $getParams);
                 }
 
-                if(!is_callable($route->getCallback()) && stripos($route->getCallback(), '@') !== false) {
-                    $c = $route->getCallback();
+                // Use controller name
+                if($route instanceof RouterController) {
+                    $c = $route->getController();
+                } else {
+
+                    // Use callback if it's not a function
+                    if (stripos($route->getCallback(), '@') !== false && !is_callable($route->getCallback())) {
+                        $c = $route->getCallback();
+                    }
+
                 }
+
             }
 
             if($c === $controller || strpos($c, $controller) === 0) {

--- a/src/Pecee/SimpleRouter/RouterController.php
+++ b/src/Pecee/SimpleRouter/RouterController.php
@@ -4,11 +4,10 @@ namespace Pecee\SimpleRouter;
 use Pecee\Exception\RouterException;
 use Pecee\Http\Request;
 
-class RouterController extends RouterEntry implements ILoadableRoute, IControllerRoute {
+class RouterController extends LoadableRoute implements IControllerRoute {
 
     const DEFAULT_METHOD = 'index';
 
-    protected $url;
     protected $controller;
     protected $method;
 
@@ -18,7 +17,7 @@ class RouterController extends RouterEntry implements ILoadableRoute, IControlle
     }
 
     public function renderRoute(Request $request) {
-        if(is_object($this->getCallback()) && is_callable($this->getCallback())) {
+        if($this->getCallback() !== null && is_callable($this->getCallback())) {
 
             // When the callback is a function
             call_user_func_array($this->getCallback(), $this->getParameters());
@@ -67,23 +66,6 @@ class RouterController extends RouterEntry implements ILoadableRoute, IControlle
             }
         }
         return null;
-    }
-
-    /**
-     * @return string
-     */
-    public function getUrl() {
-        return $this->url;
-    }
-
-    /**
-     * @param string $url
-     * @return static
-     */
-    public function setUrl($url) {
-        $url = rtrim($url, '/') . '/';
-        $this->url = $url;
-        return $this;
     }
 
     /**

--- a/src/Pecee/SimpleRouter/RouterController.php
+++ b/src/Pecee/SimpleRouter/RouterController.php
@@ -57,7 +57,7 @@ class RouterController extends LoadableRoute implements IControllerRoute {
                 $this->method = $method;
 
                 array_shift($path);
-                $this->settings['parameters'] = $path;
+                $this->parameters = $path;
 
                 // Set callback
                 $this->setCallback($this->controller . '@' . $this->method);

--- a/src/Pecee/SimpleRouter/RouterEntry.php
+++ b/src/Pecee/SimpleRouter/RouterEntry.php
@@ -22,14 +22,15 @@ abstract class RouterEntry {
         self::REQUEST_TYPE_PATCH,
     ];
 
+    protected $parent;
+    protected $callback;
+
     protected $settings = [
         'requestMethods' => array(),
         'where' => array(),
         'parameters' => array(),
         'middleware' => array(),
     ];
-
-    protected $callback;
 
     /**
      * @param string $callback
@@ -95,14 +96,14 @@ abstract class RouterEntry {
      * @return string|array
      */
     public function getMiddleware() {
-        return $this->settingArray('middleware');
+        return $this->getSetting('middleware');
     }
 
     /**
      * @return string
      */
     public function getNamespace() {
-        return $this->setting('namespace');
+        return $this->getSetting('namespace');
     }
 
     /**
@@ -116,7 +117,7 @@ abstract class RouterEntry {
      * @return array
      */
     public function getParameters(){
-        return $this->setting('parameters', array());
+        return $this->getSetting('parameters', array());
     }
 
     /**
@@ -209,7 +210,7 @@ abstract class RouterEntry {
                 // Check for optional parameter
 
                 // Use custom parameter regex if it exists
-                if(is_array($this->setting('where')) && isset($this->settings['where'][$parameter])) {
+                if(is_array($this->getSetting('where')) && isset($this->settings['where'][$parameter])) {
                     $parameterRegex = $this->settings['where'][$parameter];
                 }
 
@@ -284,7 +285,7 @@ abstract class RouterEntry {
     }
 
     public function renderRoute(Request $request) {
-        if(is_object($this->getCallback()) && is_callable($this->getCallback())) {
+        if($this->getCallback() !== null && is_callable($this->getCallback())) {
             // When the callback is a function
             call_user_func_array($this->getCallback(), $this->getParameters());
         } else {
@@ -328,30 +329,23 @@ abstract class RouterEntry {
      * @return array
      */
     public function getRequestMethods() {
-        return $this->settingArray('requestMethods');
+        return $this->getSetting('requestMethods');
     }
 
-    public function getGroup() {
-        return $this->setting('group');
+    /**
+     * @return RouterEntry
+     */
+    public function getParent() {
+        return $this->parent;
     }
 
-    public function setGroup($group) {
-        $this->settings['group'] = $group;
+    public function setParent(RouterEntry $parent) {
+        $this->parent = $parent;
         return $this;
     }
 
-    protected function setting($name, $defaultValue = null) {
+    protected function getSetting($name, $defaultValue = null) {
         return isset($this->settings[$name]) ? $this->settings[$name] : $defaultValue;
-    }
-
-    protected function settingArray($name) {
-        $value = $this->setting($name);
-
-        if($value === null) {
-            return [];
-        }
-
-        return (!is_array($value)) ? array($value) : $value;
     }
 
     abstract function matchRoute(Request $request);

--- a/src/Pecee/SimpleRouter/RouterEntry.php
+++ b/src/Pecee/SimpleRouter/RouterEntry.php
@@ -8,175 +8,31 @@ use Pecee\Http\Request;
 
 abstract class RouterEntry {
 
-    const REQUEST_TYPE_POST = 'post';
     const REQUEST_TYPE_GET = 'get';
+    const REQUEST_TYPE_POST = 'post';
     const REQUEST_TYPE_PUT = 'put';
     const REQUEST_TYPE_PATCH = 'patch';
+    const REQUEST_TYPE_OPTIONS = 'options';
     const REQUEST_TYPE_DELETE = 'delete';
 
     public static $allowedRequestTypes = [
-        self::REQUEST_TYPE_DELETE,
         self::REQUEST_TYPE_GET,
         self::REQUEST_TYPE_POST,
         self::REQUEST_TYPE_PUT,
         self::REQUEST_TYPE_PATCH,
+        self::REQUEST_TYPE_OPTIONS,
+        self::REQUEST_TYPE_DELETE,
     ];
 
     protected $parent;
     protected $callback;
 
-    protected $settings = [
-        'requestMethods' => array(),
-        'where' => array(),
-        'parameters' => array(),
-        'middleware' => array(),
-    ];
-
-    /**
-     * @param string $callback
-     * @return static
-     */
-    public function setCallback($callback) {
-        $this->callback = $callback;
-        return $this;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getCallback() {
-        return $this->callback;
-    }
-
-    public function getMethod() {
-        if(strpos($this->callback, '@') !== false) {
-            $tmp = explode('@', $this->callback);
-            return $tmp[1];
-        }
-        return null;
-    }
-
-    public function getClass() {
-        if(strpos($this->callback, '@') !== false) {
-            $tmp = explode('@', $this->callback);
-            return $tmp[0];
-        }
-        return null;
-    }
-
-    public function setMethod($method) {
-        $this->callback = sprintf('%s@%s', $this->getClass(), $method);
-        return $this;
-    }
-
-    public function setClass($class) {
-        $this->callback = sprintf('%s@%s', $class, $this->getMethod());
-        return $this;
-    }
-
-    /**
-     * @param string $middleware
-     * @return static
-     */
-    public function setMiddleware($middleware) {
-        $this->settings['middleware'][] = $middleware;
-        return $this;
-    }
-
-    /**
-     * @param string $namespace
-     * @return static
-     */
-    public function setNamespace($namespace) {
-        $this->settings['namespace'] = $namespace;
-        return $this;
-    }
-
-    /**
-     * @return string|array
-     */
-    public function getMiddleware() {
-        return $this->getSetting('middleware');
-    }
-
-    /**
-     * @return string
-     */
-    public function getNamespace() {
-        return $this->getSetting('namespace');
-    }
-
-    /**
-     * @return array
-     */
-    public function getSettings() {
-        return $this->settings;
-    }
-
-    /**
-     * @return array
-     */
-    public function getParameters(){
-        return $this->getSetting('parameters', array());
-    }
-
-    /**
-     * @param mixed $parameters
-     * @return static
-     */
-    public function setParameters($parameters) {
-        $this->settings['parameters'] = $parameters;
-        return $this;
-    }
-
-    /**
-     * Add regular expression parameter match
-     *
-     * @param array $options
-     * @return static
-     */
-    public function where(array $options) {
-        $this->settings['where'] = array_merge($this->settings['where'], $options);
-        return $this;
-    }
-
-    /**
-     * Add regular expression match for url
-     *
-     * @param string $regex
-     * @return static
-     */
-    public function match($regex) {
-        $this->settings['regexMatch'] = $regex;
-        return $this;
-    }
-
-    /**
-     * Get settings that are allowed to be inherited by child routes.
-     *
-     * @return array
-     */
-    public function getMergeableSettings() {
-        return $this->settings;
-    }
-
-    /**
-     * @param array $settings
-     * @return static
-     */
-    public function addSettings(array $settings) {
-        $this->settings = array_merge($this->settings, $settings);
-        return $this;
-    }
-
-    /**
-     * @param array $settings
-     * @return static
-     */
-    public function setSettings($settings) {
-        $this->settings = $settings;
-        return $this;
-    }
+    protected $namespace;
+    protected $regex;
+    protected $requestMethods = array();
+    protected $where = array();
+    protected $parameters = array();
+    protected $middlewares = array();
 
     protected function loadClass($name) {
         if(!class_exists($name)) {
@@ -210,8 +66,8 @@ abstract class RouterEntry {
                 // Check for optional parameter
 
                 // Use custom parameter regex if it exists
-                if(is_array($this->getSetting('where')) && isset($this->settings['where'][$parameter])) {
-                    $parameterRegex = $this->settings['where'][$parameter];
+                if(is_array($this->where) && isset($this->where[$parameter])) {
+                    $parameterRegex = $this->where[$parameter];
                 }
 
                 if($lastCharacter === '?') {
@@ -271,8 +127,8 @@ abstract class RouterEntry {
     }
 
     public function loadMiddleware(Request $request, RouterEntry &$route) {
-        if(count($this->getMiddleware())) {
-            foreach($this->getMiddleware() as $middleware) {
+        if(count($this->getMiddlewares())) {
+            foreach($this->getMiddlewares() as $middleware) {
                 $middleware = $this->loadClass($middleware);
                 if (!($middleware instanceof IMiddleware)) {
                     throw new RouterException($middleware . ' must be instance of Middleware');
@@ -319,7 +175,7 @@ abstract class RouterEntry {
      * @return static $this
      */
     public function setRequestMethods(array $methods) {
-        $this->settings['requestMethods'] = $methods;
+        $this->requestMethods = $methods;
         return $this;
     }
 
@@ -329,7 +185,7 @@ abstract class RouterEntry {
      * @return array
      */
     public function getRequestMethods() {
-        return $this->getSetting('requestMethods');
+        return $this->requestMethods;
     }
 
     /**
@@ -339,13 +195,203 @@ abstract class RouterEntry {
         return $this->parent;
     }
 
+    /**
+     * Set parent route
+     * @param RouterEntry $parent
+     * @return static $this
+     */
     public function setParent(RouterEntry $parent) {
         $this->parent = $parent;
         return $this;
     }
 
-    protected function getSetting($name, $defaultValue = null) {
-        return isset($this->settings[$name]) ? $this->settings[$name] : $defaultValue;
+    /**
+     * @param string $callback
+     * @return static
+     */
+    public function setCallback($callback) {
+        $this->callback = $callback;
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getCallback() {
+        return $this->callback;
+    }
+
+    public function getMethod() {
+        if(strpos($this->callback, '@') !== false) {
+            $tmp = explode('@', $this->callback);
+            return $tmp[1];
+        }
+        return null;
+    }
+
+    public function getClass() {
+        if(strpos($this->callback, '@') !== false) {
+            $tmp = explode('@', $this->callback);
+            return $tmp[0];
+        }
+        return null;
+    }
+
+    public function setMethod($method) {
+        $this->callback = sprintf('%s@%s', $this->getClass(), $method);
+        return $this;
+    }
+
+    public function setClass($class) {
+        $this->callback = sprintf('%s@%s', $class, $this->getMethod());
+        return $this;
+    }
+
+    /**
+     * @param string $middleware
+     * @return static
+     */
+    public function setMiddleware($middleware) {
+        $this->middlewares[] = $middleware;
+        return $this;
+    }
+
+    public function setMiddlewares(array $middlewares) {
+        $this->middlewares = $middlewares;
+        return $this;
+    }
+
+    /**
+     * @param string $namespace
+     * @return static
+     */
+    public function setNamespace($namespace) {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * @return string|array
+     */
+    public function getMiddlewares() {
+        return $this->middlewares;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNamespace() {
+        return $this->namespace;
+    }
+
+    /**
+     * @return array
+     */
+    public function getParameters(){
+        return $this->parameters;
+    }
+
+    /**
+     * @param mixed $parameters
+     * @return static
+     */
+    public function setParameters($parameters) {
+        $this->parameters = $parameters;
+        return $this;
+    }
+
+    /**
+     * Add regular expression parameter match
+     *
+     * @param array $options
+     * @return static
+     */
+    public function where(array $options) {
+        $this->where = $options;
+        return $this;
+    }
+
+    /**
+     * Add regular expression match for url
+     *
+     * @param string $regex
+     * @return static
+     */
+    public function match($regex) {
+        $this->regex = $regex;
+        return $this;
+    }
+
+    /**
+     * Get arguments that can be inherited by child routes.
+     *
+     * @return array
+     */
+    public function getMergeableData() {
+
+        $output = [
+            'namespace' => $this->namespace,
+        ];
+
+        if(count($this->middlewares)) {
+            $output['middleware'] = $this->middlewares;
+        }
+
+        if(count($this->where)) {
+            $output['where'] = $this->where;
+        }
+
+        if(count($this->requestMethods)) {
+            $output['method'] = $this->requestMethods;
+        }
+
+        if(count($this->parameters)) {
+            $output['parameters'] = $this->parameters;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Set arguments/data by array
+     *
+     * @param array $settings
+     * @return static
+     */
+    public function setData(array $settings) {
+
+        if (isset($settings['namespace'])) {
+            $this->setNamespace($settings['namespace']);
+        }
+
+        // Push middleware if multiple
+        if (isset($settings['middleware'])) {
+
+            if (!is_array($settings['middleware'])) {
+                $settings['middleware'] = array_merge($this->middlewares, array($settings['middleware']));
+            } else {
+                $settings['middleware'][] = $this->middlewares;
+            }
+
+            $middlewares = is_array($settings['middleware']) ? $settings['middleware'] : array($settings['middleware']);
+            $this->middlewares = array_reverse(array_merge($this->middlewares, $middlewares));
+
+        }
+
+        if(isset($settings['method'])) {
+            $requestMethods = is_array($settings['method']) ? $settings['method'] : array($settings['method']);
+            $this->setRequestMethods($requestMethods);
+        }
+
+        if(isset($settings['where'])) {
+            $this->where($settings['where']);
+        }
+
+        if(isset($settings['parameters'])) {
+            $this->setParameters($settings['parameters']);
+        }
+
+        return $this;
     }
 
     abstract function matchRoute(Request $request);

--- a/src/Pecee/SimpleRouter/RouterGroup.php
+++ b/src/Pecee/SimpleRouter/RouterGroup.php
@@ -7,12 +7,18 @@ use Pecee\Http\Request;
 
 class RouterGroup extends RouterEntry {
 
+    public function __construct() {
+        $this->settings = array_merge($this->settings, [
+            'exceptionHandlers' => array()
+        ]);
+    }
+
     public function matchDomain(Request $request) {
-        if($this->setting('domain') !== null) {
+        if($this->getSetting('domain') !== null) {
 
-            if(is_array($this->setting('domain'))) {
+            if(is_array($this->getSetting('domain'))) {
 
-                for($i = 0; $i < count($this->setting('domain')); $i++) {
+                for($i = 0; $i < count($this->getSetting('domain')); $i++) {
                     $domain = $this->settings['domain'][$i];
 
                     $parameters = $this->parseParameters($domain, $request->getHost(), '[^.]*');
@@ -26,7 +32,7 @@ class RouterGroup extends RouterEntry {
                 return false;
             }
 
-            $parameters = $this->parseParameters($this->setting('domain'), $request->getHost(), '[^.]*');
+            $parameters = $this->parseParameters($this->getSetting('domain'), $request->getHost(), '[^.]*');
 
             if ($parameters !== null) {
                 $this->settings['parameters'] = $parameters;
@@ -43,8 +49,8 @@ class RouterGroup extends RouterEntry {
         // Check if request method is allowed
         $hasAccess = true;
 
-        if($this->setting('method') !== null) {
-            if(is_array($this->setting('method'))) {
+        if($this->getSetting('method') !== null) {
+            if(is_array($this->getSetting('method'))) {
                 $hasAccess = (in_array($request->getMethod(), $this->getRequestMethods()));
             } else {
                 $hasAccess = strtolower($this->getRequestMethods()) == strtolower($request->getMethod());
@@ -69,17 +75,17 @@ class RouterGroup extends RouterEntry {
         return $this->matchDomain($request);
     }
 
-    public function setExceptionHandler($class) {
-        $this->settings['exceptionHandler'] = $class;
+    public function setExceptionHandlers($class) {
+        $this->settings['exceptionHandlers'][] = $class;
         return $this;
     }
 
-    public function getExceptionHandler() {
-        return $this->setting('exceptionHandler');
+    public function getExceptionHandlers() {
+        return $this->getSetting('exceptionHandlers');
     }
 
     public function getDomain() {
-        return $this->setting('domain');
+        return $this->getSetting('domain');
     }
 
     /**
@@ -87,7 +93,7 @@ class RouterGroup extends RouterEntry {
      * @return static
      */
     public function setPrefix($prefix) {
-        $this->settings['prefix'] = '/' . ltrim($prefix, '/');
+        $this->settings['prefix'] = '/' . trim($prefix, '/');
         return $this;
     }
 
@@ -95,7 +101,7 @@ class RouterGroup extends RouterEntry {
      * @return string
      */
     public function getPrefix() {
-        return $this->setting('prefix');
+        return $this->getSetting('prefix');
     }
 
     /**
@@ -118,7 +124,11 @@ class RouterGroup extends RouterEntry {
             }
 
             $settings['middleware'] = array_unique(array_reverse($settings['middleware']));
+        }
 
+        if(isset($settings['prefix'])) {
+            $this->setPrefix($settings['prefix']);
+            unset($settings['prefix']);
         }
 
         $this->settings = array_merge($this->settings, $settings);

--- a/src/Pecee/SimpleRouter/RouterGroup.php
+++ b/src/Pecee/SimpleRouter/RouterGroup.php
@@ -2,41 +2,25 @@
 
 namespace Pecee\SimpleRouter;
 
-use Pecee\Exception\RouterException;
 use Pecee\Http\Request;
 
 class RouterGroup extends RouterEntry {
 
-    public function __construct() {
-        $this->settings = array_merge($this->settings, [
-            'exceptionHandlers' => array()
-        ]);
-    }
+    protected $prefix;
+    protected $domains = array();
+    protected $exceptionHandlers = array();
 
     public function matchDomain(Request $request) {
-        if($this->getSetting('domain') !== null) {
+        if(count($this->domains)) {
+            for($i = 0; $i < count($this->domains); $i++) {
+                $domain = $this->domains[$i];
 
-            if(is_array($this->getSetting('domain'))) {
+                $parameters = $this->parseParameters($domain, $request->getHost(), '.*');
 
-                for($i = 0; $i < count($this->getSetting('domain')); $i++) {
-                    $domain = $this->settings['domain'][$i];
-
-                    $parameters = $this->parseParameters($domain, $request->getHost(), '[^.]*');
-
-                    if($parameters !== null) {
-                        $this->settings['parameters'] = $parameters;
-                        return true;
-                    }
+                if($parameters !== null) {
+                    $this->parameters = $parameters;
+                    return true;
                 }
-
-                return false;
-            }
-
-            $parameters = $this->parseParameters($this->getSetting('domain'), $request->getHost(), '[^.]*');
-
-            if ($parameters !== null) {
-                $this->settings['parameters'] = $parameters;
-                return true;
             }
 
             return false;
@@ -45,47 +29,31 @@ class RouterGroup extends RouterEntry {
         return true;
     }
 
-    public function renderRoute(Request $request) {
-        // Check if request method is allowed
-        $hasAccess = true;
-
-        if($this->getSetting('method') !== null) {
-            if(is_array($this->getSetting('method'))) {
-                $hasAccess = (in_array($request->getMethod(), $this->getRequestMethods()));
-            } else {
-                $hasAccess = strtolower($this->getRequestMethods()) == strtolower($request->getMethod());
-            }
-        }
-
-        if(!$hasAccess) {
-            throw new RouterException('Method not allowed');
-        }
-
-        $this->matchDomain($request);
-
-        return parent::renderRoute($request);
-    }
-
     public function matchRoute(Request $request) {
         // Skip if prefix doesn't match
-        if($this->getPrefix() !== null && stripos($request->getUri(), $this->getPrefix()) === false) {
+        if($this->prefix !== null && stripos($request->getUri(), $this->prefix) === false) {
             return false;
         }
 
         return $this->matchDomain($request);
     }
 
-    public function setExceptionHandlers($class) {
-        $this->settings['exceptionHandlers'][] = $class;
+    public function setExceptionHandlers(array $handlers) {
+        $this->exceptionHandlers = $handlers;
         return $this;
     }
 
     public function getExceptionHandlers() {
-        return $this->getSetting('exceptionHandlers');
+        return $this->exceptionHandlers;
     }
 
-    public function getDomain() {
-        return $this->getSetting('domain');
+    public function getDomains() {
+        return $this->domains;
+    }
+
+    public function setDomains(array $domains) {
+        $this->domains = $domains;
+        return $this;
     }
 
     /**
@@ -93,7 +61,7 @@ class RouterGroup extends RouterEntry {
      * @return static
      */
     public function setPrefix($prefix) {
-        $this->settings['prefix'] = '/' . trim($prefix, '/');
+        $this->prefix = '/' . trim($prefix, '/');
         return $this;
     }
 
@@ -101,48 +69,26 @@ class RouterGroup extends RouterEntry {
      * @return string
      */
     public function getPrefix() {
-        return $this->getSetting('prefix');
+        return $this->prefix;
     }
 
-    /**
-     * @param array $settings
-     * @return static
-     */
-    public function addSettings(array $settings) {
-
-        if ($this->getNamespace() !== null && isset($settings['namespace'])) {
-            unset($settings['namespace']);
-        }
-
-        // Push middleware if multiple
-        if ($this->getMiddleware() !== null && isset($settings['middleware'])) {
-
-            if (!is_array($settings['middleware'])) {
-                $settings['middleware'] = array_merge($this->getMiddleware(), array($settings['middleware']));
-            } else {
-                $settings['middleware'][] = $this->getMiddleware();
-            }
-
-            $settings['middleware'] = array_unique(array_reverse($settings['middleware']));
-        }
+    public function setData(array $settings) {
 
         if(isset($settings['prefix'])) {
             $this->setPrefix($settings['prefix']);
-            unset($settings['prefix']);
         }
 
-        $this->settings = array_merge($this->settings, $settings);
-        return $this;
-    }
-
-    public function getMergeableSettings() {
-        $settings = $this->settings;
-
-        if(isset($settings['prefix'])) {
-            unset($settings['prefix']);
+        if(isset($settings['exceptionHandler'])) {
+            $handlers = is_array($settings['exceptionHandler']) ? $settings['exceptionHandler'] : array($settings['exceptionHandler']);
+            $this->setExceptionHandlers($handlers);
         }
 
-        return $settings;
+        if(isset($settings['domain'])) {
+            $domains = is_array($settings['domain']) ? $settings['domain'] : array($settings['domain']);
+            $this->setDomains($domains);
+        }
+
+        return parent::setData($settings);
     }
 
 }

--- a/src/Pecee/SimpleRouter/RouterResource.php
+++ b/src/Pecee/SimpleRouter/RouterResource.php
@@ -4,9 +4,8 @@ namespace Pecee\SimpleRouter;
 use Pecee\Exception\RouterException;
 use Pecee\Http\Request;
 
-class RouterResource extends RouterEntry implements ILoadableRoute, IControllerRoute {
+class RouterResource extends LoadableRoute implements IControllerRoute {
 
-    protected $url;
     protected $controller;
 
     public function __construct($url, $controller) {
@@ -15,7 +14,7 @@ class RouterResource extends RouterEntry implements ILoadableRoute, IControllerR
     }
 
     public function renderRoute(Request $request) {
-        if(is_object($this->getCallback()) && is_callable($this->getCallback())) {
+        if($this->getCallback() !== null && is_callable($this->getCallback())) {
             // When the callback is a function
             call_user_func_array($this->getCallback(), $this->getParameters());
         } else {
@@ -95,22 +94,6 @@ class RouterResource extends RouterEntry implements ILoadableRoute, IControllerR
         }
 
         return null;
-    }
-
-    /**
-     * @return string
-     */
-    public function getUrl() {
-        return $this->url;
-    }
-
-    /**
-     * @param string $url
-     * @return static
-     */
-    public function setUrl($url) {
-        $this->url = rtrim($url, '/') . '/';
-        return $this;
     }
 
     /**

--- a/src/Pecee/SimpleRouter/RouterResource.php
+++ b/src/Pecee/SimpleRouter/RouterResource.php
@@ -38,7 +38,7 @@ class RouterResource extends LoadableRoute implements IControllerRoute {
 
     protected function call($method, $parameters) {
         $this->setCallback($this->controller . '@' . $method);
-        $this->settings['parameters'] = $parameters;
+        $this->parameters = $parameters;
         return true;
     }
 
@@ -53,7 +53,7 @@ class RouterResource extends LoadableRoute implements IControllerRoute {
         if($parameters !== null) {
 
             if(is_array($parameters)) {
-                $parameters = array_merge($this->settings['parameters'], $parameters);
+                $parameters = array_merge($this->parameters, $parameters);
             }
 
             $action = isset($parameters['action']) ? $parameters['action'] : null;

--- a/src/Pecee/SimpleRouter/RouterRoute.php
+++ b/src/Pecee/SimpleRouter/RouterRoute.php
@@ -17,10 +17,10 @@ class RouterRoute extends LoadableRoute {
         $url = rtrim($url, '/') . '/';
 
         // Match on custom defined regular expression
-        if($this->getSetting('regexMatch') !== null) {
+        if($this->regex !== null) {
             $parameters = array();
-            if(preg_match('/(' . $this->getSetting('regexMatch') . ')/is', $request->getHost() . $url, $parameters)) {
-                $this->settings['parameters'] = (!is_array($parameters[0]) ? array($parameters[0]) : $parameters[0]);
+            if(preg_match('/(' . $this->regex . ')/is', $request->getHost() . $url, $parameters)) {
+                $this->parameters = (!is_array($parameters[0]) ? array($parameters[0]) : $parameters[0]);
                 return true;
             }
             return null;
@@ -32,7 +32,7 @@ class RouterRoute extends LoadableRoute {
         $parameters = $this->parseParameters($route, $url);
 
         if($parameters !== null) {
-            $this->settings['parameters'] = array_merge($this->getSetting('parameters'), $parameters);
+            $this->parameters = array_merge($this->parameters, $parameters);
             return true;
         }
 

--- a/src/Pecee/SimpleRouter/RouterRoute.php
+++ b/src/Pecee/SimpleRouter/RouterRoute.php
@@ -4,11 +4,7 @@ namespace Pecee\SimpleRouter;
 
 use Pecee\Http\Request;
 
-class RouterRoute extends RouterEntry implements ILoadableRoute {
-
-    const PARAMETERS_REGEX_MATCH = '{([A-Za-z\-\_]*?)\?{0,1}}';
-
-    protected $url;
+class RouterRoute extends LoadableRoute {
 
     public function __construct($url, $callback) {
         $this->setUrl($url);
@@ -21,9 +17,9 @@ class RouterRoute extends RouterEntry implements ILoadableRoute {
         $url = rtrim($url, '/') . '/';
 
         // Match on custom defined regular expression
-        if($this->setting('regexMatch') !== null) {
+        if($this->getSetting('regexMatch') !== null) {
             $parameters = array();
-            if(preg_match('/(' . $this->setting('regexMatch') . ')/is', $request->getHost() . $url, $parameters)) {
+            if(preg_match('/(' . $this->getSetting('regexMatch') . ')/is', $request->getHost() . $url, $parameters)) {
                 $this->settings['parameters'] = (!is_array($parameters[0]) ? array($parameters[0]) : $parameters[0]);
                 return true;
             }
@@ -36,92 +32,11 @@ class RouterRoute extends RouterEntry implements ILoadableRoute {
         $parameters = $this->parseParameters($route, $url);
 
         if($parameters !== null) {
-            $this->settings['parameters'] = array_merge($this->settingArray('parameters'), $parameters);
+            $this->settings['parameters'] = array_merge($this->getSetting('parameters'), $parameters);
             return true;
         }
 
         return null;
-    }
-
-    /**
-     * @return string
-     */
-    public function getUrl() {
-        return $this->url;
-    }
-
-    /**
-     * @param string $url
-     * @return static
-     */
-    public function setUrl($url) {
-        $parameters = array();
-        $matches = array();
-
-        if(preg_match_all('/' . static::PARAMETERS_REGEX_MATCH . '/is', $url, $matches)) {
-            $parameters = $matches[1];
-        }
-
-        if(count($parameters)) {
-
-            foreach(array_keys($parameters) as $key) {
-                $parameters[$key] = null;
-            }
-
-            $this->settings['parameters'] = $parameters;
-        }
-
-        $this->url = $url;
-        return $this;
-    }
-
-    /**
-     * Get alias for the url which can be used when getting the url route.
-     * @return string|array
-     */
-    public function getAlias(){
-        return $this->setting('alias');
-    }
-
-    /**
-     * Check if route has given alias.
-     *
-     * @param string $name
-     * @return bool
-     */
-    public function hasAlias($name) {
-        if ($this->getAlias() !== null) {
-            if (is_array($this->getAlias())) {
-                foreach ($this->setting('alias') as $alias) {
-                    if (strtolower($alias) === strtolower($name)) {
-                        return true;
-                    }
-                }
-            }
-            return strtolower($this->getAlias()) === strtolower($name);
-        }
-
-        return false;
-    }
-
-    /**
-     * Set the url alias for easier getting the url route.
-     * @param string|array $alias
-     * @return static
-     */
-    public function setAlias($alias){
-        $this->settings['alias'] = $alias;
-        return $this;
-    }
-
-    public function addSettings(array $settings) {
-
-        // Change as to alias
-        if(isset($settings['as'])) {
-            $this->setAlias($settings['as']);
-        }
-
-        return parent::addSettings($settings);
     }
 
 }

--- a/src/Pecee/SimpleRouter/SimpleRouter.php
+++ b/src/Pecee/SimpleRouter/SimpleRouter.php
@@ -53,6 +53,14 @@ class SimpleRouter {
         return static::match(['put'], $url, $callback, $settings);
     }
 
+    public static function patch($url, $callback, array $settings = null) {
+        return static::match(['patch'], $url, $callback, $settings);
+    }
+
+    public static function options($url, $callback, array $settings = null) {
+        return static::match(['options'], $url, $callback, $settings);
+    }
+
     public static function delete($url, $callback, array $settings = null) {
         return static::match(['delete'], $url, $callback, $settings);
     }
@@ -62,7 +70,7 @@ class SimpleRouter {
         $group->setCallback($callback);
 
         if($settings !== null && is_array($settings)) {
-            $group->setSettings($settings);
+            $group->setData($settings);
         }
 
         RouterBase::getInstance()->addRoute($group);
@@ -87,7 +95,7 @@ class SimpleRouter {
         $route->setRequestMethods($requestMethods);
 
         if($settings !== null) {
-            $route->addSettings($settings);
+            $route->setData($settings);
         }
 
         RouterBase::getInstance()->addRoute($route);
@@ -99,7 +107,7 @@ class SimpleRouter {
         $route = new RouterRoute($url, $callback);
 
         if($settings !== null) {
-            $route->addSettings($settings);
+            $route->setData($settings);
         }
 
         RouterBase::getInstance()->addRoute($route);
@@ -111,7 +119,7 @@ class SimpleRouter {
         $route = new RouterController($url, $controller);
 
         if($settings !== null) {
-            $route->addSettings($settings);
+            $route->setData($settings);
         }
 
         RouterBase::getInstance()->addRoute($route);
@@ -123,7 +131,7 @@ class SimpleRouter {
         $route = new RouterResource($url, $controller);
 
         if($settings !== null) {
-            $route->addSettings($settings);
+            $route->setData($settings);
         }
 
         static::router()->addRoute($route);

--- a/test/GroupTest.php
+++ b/test/GroupTest.php
@@ -18,7 +18,7 @@ class GroupTest extends PHPUnit_Framework_TestCase  {
         try {
             \Pecee\SimpleRouter\SimpleRouter::start();
         } catch(Exception $e) {
-            echo $e->getMessage();
+            // ignore RouteNotFound exception
         }
 
         $this->assertTrue($this->result);

--- a/test/RouterRouteTest.php
+++ b/test/RouterRouteTest.php
@@ -6,6 +6,7 @@ require_once 'Dummy/Handler/ExceptionHandler.php';
 
 class RouterRouteTest extends PHPUnit_Framework_TestCase  {
 
+    protected $result = false;
 
     public function testNotFound() {
         \Pecee\SimpleRouter\RouterBase::getInstance()->reset();
@@ -110,6 +111,27 @@ class RouterRouteTest extends PHPUnit_Framework_TestCase  {
 
         \Pecee\SimpleRouter\SimpleRouter::get('/test/path/{myParam}', 'DummyController@param', ['where' => ['myParam' => '([0-9]+)']]);
         \Pecee\SimpleRouter\SimpleRouter::start();
+
+    }
+
+    public function testDomainRoute() {
+
+        \Pecee\SimpleRouter\RouterBase::getInstance()->reset();
+        \Pecee\SimpleRouter\SimpleRouter::request()->setMethod('get');
+        \Pecee\SimpleRouter\SimpleRouter::request()->setUri('/test');
+        \Pecee\SimpleRouter\SimpleRouter::request()->setHost('hello.world.com');
+
+        $this->result = false;
+
+        \Pecee\SimpleRouter\SimpleRouter::group(['domain' => '{subdomain}.world.com'], function() {
+            \Pecee\SimpleRouter\SimpleRouter::get('test', function($subdomain) {
+                $this->result = ($subdomain === 'hello');
+            });
+        });
+
+        \Pecee\SimpleRouter\SimpleRouter::start();
+
+        $this->assertTrue($this->result);
 
     }
 


### PR DESCRIPTION
- Parameters are no longer automatically merged. Though this might increase the code-size a little when mapping the properties from the array, it was done with a performance decision in mind and to avoid calling `isset` each time a magic-property was called. Plus it should give a little more control over what data the properties actually contains.

- Added `SimpleRouter::patch` and `SimpleRouter::delete` methods.

- Added `LoadableRoute` abstract class. This class contains basic functionality used by loadable routes (`RouterRoute`, `RouterController`, `RouterRessource` etc).

- Cleaned up `RouterGroup` and removed unused/old functionality.

- Changed demo-project to use version-2 of router.

- Bug fixes and optimisations.