### PR TITLE
Development

### DIFF
--- a/src/Pecee/CsrfToken.php
+++ b/src/Pecee/CsrfToken.php
@@ -14,8 +14,8 @@ class CsrfToken
      */
     public static function generateToken()
     {
-        if (function_exists('mcrypt_create_iv')) {
-            return bin2hex(mcrypt_create_iv(32, MCRYPT_DEV_URANDOM));
+        if (function_exists('random_bytes')) {
+            return bin2hex(random_bytes(32));
         }
 
         return bin2hex(openssl_random_pseudo_bytes(32));

--- a/src/Pecee/Http/Input/IInputItem.php
+++ b/src/Pecee/Http/Input/IInputItem.php
@@ -6,9 +6,15 @@ interface IInputItem
 
     public function getIndex();
 
+    public function setIndex($index);
+
     public function getName();
 
+    public function setName($name);
+
     public function getValue();
+
+    public function setValue($value);
 
     public function __toString();
 

--- a/src/Pecee/Http/Input/Input.php
+++ b/src/Pecee/Http/Input/Input.php
@@ -188,10 +188,6 @@ class Input
      */
     public function all(array $filter = null)
     {
-        if ($this->invalidContentType === true) {
-            return [];
-        }
-
         $output = $_POST;
 
         if ($this->request->getMethod() === 'post') {

--- a/src/Pecee/Http/Input/InputFile.php
+++ b/src/Pecee/Http/Input/InputFile.php
@@ -4,6 +4,7 @@ namespace Pecee\Http\Input;
 class InputFile implements IInputItem
 {
     public $index;
+    public $value;
     public $name;
     public $size;
     public $type;
@@ -16,139 +17,6 @@ class InputFile implements IInputItem
 
         // Make the name human friendly, by replace _ with space
         $this->name = ucfirst(str_replace('_', ' ', $this->index));
-    }
-
-    /**
-     * @return string
-     */
-    public function getIndex()
-    {
-        return $this->index;
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return $this->name;
-    }
-
-    /**
-     * @return string
-     */
-    public function getSize()
-    {
-        return $this->size;
-    }
-
-    /**
-     * @return string
-     */
-    public function getType()
-    {
-        return $this->type;
-    }
-
-    /**
-     * @return string
-     */
-    public function getError()
-    {
-        return $this->error;
-    }
-
-    public function getMime()
-    {
-        return $this->getType();
-    }
-
-    /**
-     * @return string
-     */
-    public function getTmpName()
-    {
-        return $this->tmpName;
-    }
-
-    public function getExtension()
-    {
-        return pathinfo($this->getName(), PATHINFO_EXTENSION);
-    }
-
-    public function move($destination)
-    {
-        return move_uploaded_file($this->tmpName, $destination);
-    }
-
-    public function getContents()
-    {
-        return file_get_contents($this->tmpName);
-    }
-
-    public function setName($name)
-    {
-        $this->name = $name;
-
-        return $this;
-    }
-
-    /**
-     * Set file temp. name
-     * @param string $name
-     * @return static $this
-     */
-    public function setTmpName($name)
-    {
-        $this->tmpName = $name;
-
-        return $this;
-    }
-
-    /**
-     * Set file size
-     * @param int $size
-     * @return static $this
-     */
-    public function setSize($size)
-    {
-        $this->size = $size;
-
-        return $this;
-    }
-
-    /**
-     * Set type
-     * @param string $type
-     * @return static $this
-     */
-    public function setType($type)
-    {
-        $this->type = $type;
-
-        return $this;
-    }
-
-    /**
-     * Set error
-     * @param int $error
-     * @return static $this
-     */
-    public function setError($error)
-    {
-        $this->error = (int)$error;
-
-        return $this;
-    }
-
-    public function getValue()
-    {
-        return $this->getTmpName();
-    }
-
-    public function hasError()
-    {
-        return ($this->getError() !== 0);
     }
 
     /**
@@ -172,6 +40,128 @@ class InputFile implements IInputItem
         return $input;
     }
 
+    /**
+     * @return string
+     */
+    public function getIndex()
+    {
+        return $this->index;
+    }
+
+    public function setIndex($index)
+    {
+        $this->index = $index;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSize()
+    {
+        return $this->size;
+    }
+
+    /**
+     * Set file size
+     * @param int $size
+     * @return static $this
+     */
+    public function setSize($size)
+    {
+        $this->size = $size;
+
+        return $this;
+    }
+
+    public function getMime()
+    {
+        return $this->getType();
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * Set type
+     * @param string $type
+     * @return static $this
+     */
+    public function setType($type)
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function getExtension()
+    {
+        return pathinfo($this->getName(), PATHINFO_EXTENSION);
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function move($destination)
+    {
+        return move_uploaded_file($this->tmpName, $destination);
+    }
+
+    public function getContents()
+    {
+        return file_get_contents($this->tmpName);
+    }
+
+    public function setValue($value)
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    public function hasError()
+    {
+        return ($this->getError() !== 0);
+    }
+
+    /**
+     * @return string
+     */
+    public function getError()
+    {
+        return $this->error;
+    }
+
+    /**
+     * Set error
+     * @param int $error
+     * @return static $this
+     */
+    public function setError($error)
+    {
+        $this->error = (int)$error;
+
+        return $this;
+    }
+
     public function toArray()
     {
         return [
@@ -186,5 +176,30 @@ class InputFile implements IInputItem
     public function __toString()
     {
         return $this->getValue();
+    }
+
+    public function getValue()
+    {
+        return $this->getTmpName();
+    }
+
+    /**
+     * @return string
+     */
+    public function getTmpName()
+    {
+        return $this->tmpName;
+    }
+
+    /**
+     * Set file temp. name
+     * @param string $name
+     * @return static $this
+     */
+    public function setTmpName($name)
+    {
+        $this->tmpName = $name;
+
+        return $this;
     }
 }

--- a/src/Pecee/Http/Input/InputItem.php
+++ b/src/Pecee/Http/Input/InputItem.php
@@ -24,20 +24,19 @@ class InputItem implements IInputItem
         return $this->index;
     }
 
+    public function setIndex($index)
+    {
+        $this->index = $index;
+
+        return $this;
+    }
+
     /**
      * @return string
      */
     public function getName()
     {
         return $this->name;
-    }
-
-    /**
-     * @return string
-     */
-    public function getValue()
-    {
-        return $this->value;
     }
 
     /**
@@ -50,6 +49,14 @@ class InputItem implements IInputItem
         $this->name = $name;
 
         return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->value;
     }
 
     /**
@@ -68,5 +75,4 @@ class InputItem implements IInputItem
     {
         return (string)$this->value;
     }
-
 }

--- a/src/Pecee/SimpleRouter/Route/Route.php
+++ b/src/Pecee/SimpleRouter/Route/Route.php
@@ -384,7 +384,10 @@ abstract class Route implements IRoute
         }
 
         if (count($this->parameters) > 0) {
-            $values['parameters'] = $this->parameters;
+            /* Ensure the right order + values */
+            $parameters = ($values['parameters'] + $this->parameters);
+            $parameters = array_merge($parameters, $this->parameters);
+            $this->setParameters($parameters);
         }
 
         if (count($this->middlewares) > 0) {


### PR DESCRIPTION
- It's now possible to adjust the load-order for parameters on routes.
- Replaced PHP 7.1 deprecated `mcrypt_create_iv` function with `random_bytes` if available (requires >=PHP7)
- Added `setIndex`, `setName` and `setValue` methods to `IInputItem` to allow for extendability.
- Cleanup and bug fixes.