### PR TITLE
2.6.0

### DIFF
--- a/src/Pecee/Http/Input/Input.php
+++ b/src/Pecee/Http/Input/Input.php
@@ -94,8 +94,7 @@ class Input
 
             $path = $original[$property];
 
-            $tmp = array_values($index);
-            foreach ($tmp as $i) {
+            foreach (array_values($index) as $i) {
                 $path = $path[$i];
             }
 

--- a/src/Pecee/Http/Input/Input.php
+++ b/src/Pecee/Http/Input/Input.php
@@ -51,18 +51,17 @@ class Input
         }
 
         /* Parse get requests */
-        $this->file = $this->parseFiles();
+        if (count($_FILES) > 0) {
+            $this->file = $this->parseFiles();
+        }
     }
 
     public function parseFiles()
     {
-        if (count($_FILES) === 0) {
-            return [];
-        }
-
+        $files = $_FILES;
         $list = [];
 
-        foreach ($_FILES as $key => $value) {
+        foreach ($files as $key => $value) {
 
             // Handle array input
             if (is_array($value['name']) === false) {
@@ -95,7 +94,8 @@ class Input
 
             $path = $original[$property];
 
-            foreach (array_values($index) as $i) {
+            $tmp = array_values($index);
+            foreach ($tmp as $i) {
                 $path = $path[$i];
             }
 

--- a/src/Pecee/Http/Input/Input.php
+++ b/src/Pecee/Http/Input/Input.php
@@ -58,10 +58,9 @@ class Input
 
     public function parseFiles()
     {
-        $files = $_FILES;
         $list = [];
 
-        foreach ($files as $key => $value) {
+        foreach ($_FILES as $key => $value) {
 
             // Handle array input
             if (is_array($value['name']) === false) {

--- a/src/Pecee/Http/Input/InputFile.php
+++ b/src/Pecee/Http/Input/InputFile.php
@@ -42,14 +42,13 @@ class InputFile implements IInputItem
             'error'    => null,
         ], $values);
 
-        $input = new static($values['index']);
-        $input->setError($values['error'])
+        return (new static($values['index']))
+            ->setError($values['error'])
             ->setSize($values['size'])
             ->setType($values['type'])
             ->setTmpName($values['tmp_name'])
             ->setFilename($values['name']);
 
-        return $input;
     }
 
     /**

--- a/src/Pecee/Http/Middleware/BaseCsrfVerifier.php
+++ b/src/Pecee/Http/Middleware/BaseCsrfVerifier.php
@@ -58,7 +58,7 @@ class BaseCsrfVerifier implements IMiddleware
     public function handle(Request $request, ILoadableRoute &$route = null)
     {
 
-        if ($this->skip($request) === false && in_array($request->getMethod(), ['post', 'put', 'delete']) === true) {
+        if ($this->skip($request) === false && in_array($request->getMethod(), ['post', 'put', 'delete'], false) === true) {
 
             $token = $request->getInput()->get(static::POST_KEY, null, 'post');
 

--- a/src/Pecee/Http/Request.php
+++ b/src/Pecee/Http/Request.php
@@ -215,7 +215,7 @@ class Request
 
     public function __isset($name)
     {
-        return $this->data[$name] ?? null;
+        return array_key_exists($name, $this->data);
     }
 
     public function __set($name, $value = null)

--- a/src/Pecee/SimpleRouter/Route/ILoadableRoute.php
+++ b/src/Pecee/SimpleRouter/Route/ILoadableRoute.php
@@ -51,4 +51,19 @@ interface ILoadableRoute extends IRoute
      */
     public function setName($name);
 
+    /**
+     * Get regular expression match used for matching route (if defined).
+     *
+     * @return string
+     */
+    public function getMatch();
+
+    /**
+     * Add regular expression match for the entire route.
+     *
+     * @param string $regex
+     * @return static
+     */
+    public function setMatch($regex);
+
 }

--- a/src/Pecee/SimpleRouter/Route/IRoute.php
+++ b/src/Pecee/SimpleRouter/Route/IRoute.php
@@ -18,7 +18,8 @@ interface IRoute
      * Returns class to be rendered.
      *
      * @param Request $request
-     * @return \Closure|string
+     * @throws \Pecee\SimpleRouter\Exceptions\NotFoundHttpException
+     * @return void
      */
     public function renderRoute(Request $request);
 

--- a/src/Pecee/SimpleRouter/Route/IRoute.php
+++ b/src/Pecee/SimpleRouter/Route/IRoute.php
@@ -114,21 +114,6 @@ interface IRoute
     public function getDefaultNamespace();
 
     /**
-     * Get regular expression match used for matching route (if defined).
-     *
-     * @return string
-     */
-    public function getMatch();
-
-    /**
-     * Add regular expression match for the entire route.
-     *
-     * @param string $regex
-     * @return static
-     */
-    public function setMatch($regex);
-
-    /**
      * Get parameter names.
      *
      * @return array

--- a/src/Pecee/SimpleRouter/Route/LoadableRoute.php
+++ b/src/Pecee/SimpleRouter/Route/LoadableRoute.php
@@ -37,6 +37,7 @@ abstract class LoadableRoute extends Route implements ILoadableRoute
                 $middleware = $this->getMiddlewares()[$i];
 
                 $middleware = $this->loadClass($middleware);
+
                 if (!($middleware instanceof IMiddleware)) {
                     throw new HttpException($middleware . ' must be instance of Middleware');
                 }
@@ -60,7 +61,7 @@ abstract class LoadableRoute extends Route implements ILoadableRoute
 
             /* Remove global match */
             if (count($parameters) > 1) {
-                $this->setParameters(array_slice($parameters, 1));
+                $this->parameters = array_slice($parameters, 1);
             }
 
             return true;

--- a/src/Pecee/SimpleRouter/Route/LoadableRoute.php
+++ b/src/Pecee/SimpleRouter/Route/LoadableRoute.php
@@ -51,7 +51,7 @@ abstract class LoadableRoute extends Route implements ILoadableRoute
         /* Match on custom defined regular expression */
 
         if ($this->regex === null) {
-            return false;
+            return null;
         }
 
         $parameters = [];
@@ -60,10 +60,7 @@ abstract class LoadableRoute extends Route implements ILoadableRoute
 
             /* Remove global match */
             if (count($parameters) > 1) {
-
                 $this->setParameters(array_slice($parameters, 1));
-                //array_shift($parameters);
-                //$this->parameters = $parameters;
             }
 
             return true;

--- a/src/Pecee/SimpleRouter/Route/LoadableRoute.php
+++ b/src/Pecee/SimpleRouter/Route/LoadableRoute.php
@@ -46,6 +46,32 @@ abstract class LoadableRoute extends Route implements ILoadableRoute
         }
     }
 
+    public function matchRegex(Request $request, $url) {
+
+        /* Match on custom defined regular expression */
+
+        if ($this->regex === null) {
+            return false;
+        }
+
+        $parameters = [];
+
+        if (preg_match($this->regex, $request->getHost() . $url, $parameters) !== false) {
+
+            /* Remove global match */
+            if (count($parameters) > 1) {
+
+                $this->setParameters(array_slice($parameters, 1));
+                //array_shift($parameters);
+                //$this->parameters = $parameters;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
     /**
      * Set url
      *
@@ -61,15 +87,8 @@ abstract class LoadableRoute extends Route implements ILoadableRoute
             $regex = sprintf(static::PARAMETERS_REGEX_MATCH, $this->paramModifiers[0], $this->paramOptionalSymbol, $this->paramModifiers[1]);
 
             if (preg_match_all('/' . $regex . '/is', $this->url, $matches)) {
-
-                $max = count($matches[1]);
-
-                for ($i = 0; $i < $max; $i++) {
-                    $this->parameters[$matches[1][$i]] = null;
-                }
-
+                $this->parameters = array_fill_keys($matches[1], null);
             }
-
         }
 
         return $this;

--- a/src/Pecee/SimpleRouter/Route/LoadableRoute.php
+++ b/src/Pecee/SimpleRouter/Route/LoadableRoute.php
@@ -7,8 +7,6 @@ use Pecee\SimpleRouter\Exceptions\HttpException;
 
 abstract class LoadableRoute extends Route implements ILoadableRoute
 {
-    const PARAMETERS_REGEX_MATCH = '%s([\w\-\_]*?)\%s{0,1}%s';
-
     /**
      * @var
      */
@@ -57,12 +55,10 @@ abstract class LoadableRoute extends Route implements ILoadableRoute
 
         $parameters = [];
 
-        if (preg_match($this->regex, $request->getHost() . $url, $parameters) !== false) {
+        if (preg_match($this->regex, $request->getHost() . $url, $parameters) > 0) {
 
             /* Remove global match */
-            if (count($parameters) > 1) {
-                $this->parameters = array_slice($parameters, 1);
-            }
+            $this->parameters = array_slice($parameters, 1);
 
             return true;
         }
@@ -147,6 +143,7 @@ abstract class LoadableRoute extends Route implements ILoadableRoute
             }
         }
 
+        /** @noinspection AliasFunctionsUsageInspection */
         $url .= join('/', $unknownParams);
 
         return rtrim($url, '/') . '/';

--- a/src/Pecee/SimpleRouter/Route/LoadableRoute.php
+++ b/src/Pecee/SimpleRouter/Route/LoadableRoute.php
@@ -45,7 +45,8 @@ abstract class LoadableRoute extends Route implements ILoadableRoute
         }
     }
 
-    public function matchRegex(Request $request, $url) {
+    public function matchRegex(Request $request, $url)
+    {
 
         /* Match on custom defined regular expression */
 

--- a/src/Pecee/SimpleRouter/Route/LoadableRoute.php
+++ b/src/Pecee/SimpleRouter/Route/LoadableRoute.php
@@ -8,7 +8,7 @@ use Pecee\SimpleRouter\Exceptions\HttpException;
 abstract class LoadableRoute extends Route implements ILoadableRoute
 {
     /**
-     * @var
+     * @var string
      */
     protected $url;
 
@@ -16,6 +16,8 @@ abstract class LoadableRoute extends Route implements ILoadableRoute
      * @var string
      */
     protected $name;
+
+    protected $regex;
 
     /**
      * Loads and renders middlewares-classes
@@ -169,6 +171,29 @@ abstract class LoadableRoute extends Route implements ILoadableRoute
     public function hasName($name)
     {
         return (strtolower($this->name) === strtolower($name));
+    }
+
+    /**
+     * Add regular expression match for the entire route.
+     *
+     * @param string $regex
+     * @return static
+     */
+    public function setMatch($regex)
+    {
+        $this->regex = $regex;
+
+        return $this;
+    }
+
+    /**
+     * Get regular expression match used for matching route (if defined).
+     *
+     * @return string
+     */
+    public function getMatch()
+    {
+        return $this->regex;
     }
 
     /**

--- a/src/Pecee/SimpleRouter/Route/Route.php
+++ b/src/Pecee/SimpleRouter/Route/Route.php
@@ -47,7 +47,7 @@ abstract class Route implements IRoute
 
     protected function loadClass($name)
     {
-        if (!class_exists($name)) {
+        if (class_exists($name) === false) {
             throw new NotFoundHttpException(sprintf('Class %s does not exist', $name), 404);
         }
 
@@ -528,7 +528,6 @@ abstract class Route implements IRoute
          * If this is the first time setting parameters we store them so we
          * later can organize the array, in case somebody tried to sort the array.
          */
-
         if(count($parameters) > 0 && count($this->originalParameters) === 0) {
             $this->originalParameters = $parameters;
         }

--- a/src/Pecee/SimpleRouter/Route/Route.php
+++ b/src/Pecee/SimpleRouter/Route/Route.php
@@ -40,7 +40,6 @@ abstract class Route implements IRoute
 
     /* Default options */
     protected $namespace;
-    protected $regex;
     protected $requestMethods = [];
     protected $where = [];
     protected $parameters = [];
@@ -311,29 +310,6 @@ abstract class Route implements IRoute
     public function getNamespace()
     {
         return ($this->namespace === null) ? $this->defaultNamespace : $this->namespace;
-    }
-
-    /**
-     * Add regular expression match for the entire route.
-     *
-     * @param string $regex
-     * @return static
-     */
-    public function setMatch($regex)
-    {
-        $this->regex = $regex;
-
-        return $this;
-    }
-
-    /**
-     * Get regular expression match used for matching route (if defined).
-     *
-     * @return string
-     */
-    public function getMatch()
-    {
-        return $this->regex;
     }
 
     /**

--- a/src/Pecee/SimpleRouter/Route/Route.php
+++ b/src/Pecee/SimpleRouter/Route/Route.php
@@ -6,7 +6,7 @@ use Pecee\SimpleRouter\Exceptions\NotFoundHttpException;
 
 abstract class Route implements IRoute
 {
-    const PARAMETERS_REGEX_MATCH = '%s([\w\-\_]*?)(\%s{0,1})%s';
+    const PARAMETERS_REGEX_MATCH = '%s([\w]+)(\%s?)%s';
 
     const REQUEST_TYPE_GET = 'get';
     const REQUEST_TYPE_POST = 'post';

--- a/src/Pecee/SimpleRouter/Route/Route.php
+++ b/src/Pecee/SimpleRouter/Route/Route.php
@@ -102,11 +102,11 @@ abstract class Route implements IRoute
 
             $urlParts = preg_split('/\{[^}]+\}/is', rtrim($route, '/'));
 
-            foreach($urlParts as $key => $t) {
+            foreach ($urlParts as $key => $t) {
 
                 $regex = '';
 
-                if($key < (count($parameters[1]))) {
+                if ($key < (count($parameters[1]))) {
 
                     $name = $parameters[1][$key];
                     $regex = isset($this->where[$name]) ? $this->where[$name] : $parameterRegex;
@@ -123,12 +123,12 @@ abstract class Route implements IRoute
             $urlRegex = preg_quote($route, '/');
         }
 
-        if(preg_match('/^' . $urlRegex . '(\/?)$/is', $url, $matches) > 0) {
+        if (preg_match('/^' . $urlRegex . '(\/?)$/is', $url, $matches) > 0) {
 
             $values = [];
 
             /* Only take matched parameters with name */
-            foreach($parameters[1] as $name) {
+            foreach ($parameters[1] as $name) {
                 $values[$name] = $matches[$name];
             }
 
@@ -441,9 +441,9 @@ abstract class Route implements IRoute
     public function getParameters()
     {
         /* Sort the parameters after the user-defined param order, if any */
-        $parameters = array();
+        $parameters = [];
 
-        if(count($this->originalParameters) > 0) {
+        if (count($this->originalParameters) > 0) {
             $parameters = $this->originalParameters;
         }
 
@@ -462,7 +462,7 @@ abstract class Route implements IRoute
          * If this is the first time setting parameters we store them so we
          * later can organize the array, in case somebody tried to sort the array.
          */
-        if(count($parameters) > 0 && count($this->originalParameters) === 0) {
+        if (count($parameters) > 0 && count($this->originalParameters) === 0) {
             $this->originalParameters = $parameters;
         }
 

--- a/src/Pecee/SimpleRouter/Route/RouteController.php
+++ b/src/Pecee/SimpleRouter/Route/RouteController.php
@@ -107,7 +107,7 @@ class RouteController extends LoadableRoute implements IControllerRoute
                 //array_shift($path);
                 //$this->parameters = $path;
 
-                $this->setParameters(array_slice($path, 1));
+                $this->parameters = array_slice($path, 1);
 
                 // Set callback
                 $this->setCallback($this->controller . '@' . $this->method);

--- a/src/Pecee/SimpleRouter/Route/RouteController.php
+++ b/src/Pecee/SimpleRouter/Route/RouteController.php
@@ -63,7 +63,7 @@ class RouteController extends LoadableRoute implements IControllerRoute
         if ($method !== null) {
 
             /* Remove requestType from method-name, if it exists */
-            foreach(static::$requestTypes as $requestType) {
+            foreach (static::$requestTypes as $requestType) {
 
                 if (stripos($method, $requestType) === 0) {
                     $method = substr($method, strlen($requestType));
@@ -89,7 +89,7 @@ class RouteController extends LoadableRoute implements IControllerRoute
         $url = rtrim($url, '/') . '/';
 
         /* Match global regular-expression for route */
-        if($this->matchRegex($request, $url) === true) {
+        if ($this->matchRegex($request, $url) === true) {
             return true;
         }
 

--- a/src/Pecee/SimpleRouter/Route/RouteController.php
+++ b/src/Pecee/SimpleRouter/Route/RouteController.php
@@ -104,9 +104,6 @@ class RouteController extends LoadableRoute implements IControllerRoute
                 $method = (!isset($path[0]) || trim($path[0]) === '') ? $this->defaultMethod : $path[0];
                 $this->method = $method;
 
-                //array_shift($path);
-                //$this->parameters = $path;
-
                 $this->parameters = array_slice($path, 1);
 
                 // Set callback

--- a/src/Pecee/SimpleRouter/Route/RouteGroup.php
+++ b/src/Pecee/SimpleRouter/Route/RouteGroup.php
@@ -171,6 +171,10 @@ class RouteGroup extends Route implements IGroupRoute
             $values['as'] = $this->name;
         }
 
+        if (count($this->parameters) > 0) {
+            $values['parameters'] = $this->parameters;
+        }
+
         return array_merge($values, parent::toArray());
     }
 

--- a/src/Pecee/SimpleRouter/Route/RouteGroup.php
+++ b/src/Pecee/SimpleRouter/Route/RouteGroup.php
@@ -28,9 +28,7 @@ class RouteGroup extends Route implements IGroupRoute
 
             if ($parameters !== null && count($parameters) > 0) {
 
-                $this->setParameters($parameters);
-                //$this->parameters = array_merge($this->parameters, $parameters);
-
+                $this->parameters = $parameters;
                 return true;
             }
         }

--- a/src/Pecee/SimpleRouter/Route/RouteGroup.php
+++ b/src/Pecee/SimpleRouter/Route/RouteGroup.php
@@ -18,26 +18,24 @@ class RouteGroup extends Route implements IGroupRoute
      */
     public function matchDomain(Request $request)
     {
-        if (count($this->domains) > 0) {
-
-            $max = count($this->domains) - 1;
-
-            for ($i = $max; $i >= 0; $i--) {
-
-                $domain = $this->domains[$i];
-                $parameters = $this->parseParameters($domain, $request->getHost(), '.*');
-
-                if ($parameters !== null && count($parameters) > 0) {
-                    $this->parameters = array_merge($this->parameters, $parameters);
-
-                    return true;
-                }
-            }
-
-            return false;
+        if (count($this->domains) === 0) {
+            return true;
         }
 
-        return true;
+        foreach($this->domains as $domain) {
+
+            $parameters = $this->parseParameters($domain, $request->getHost(), '.*');
+
+            if ($parameters !== null && count($parameters) > 0) {
+
+                $this->setParameters($parameters);
+                //$this->parameters = array_merge($this->parameters, $parameters);
+
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -48,7 +46,7 @@ class RouteGroup extends Route implements IGroupRoute
      */
     public function matchRoute(Request $request)
     {
-        // Skip if prefix doesn't match
+        /* Skip if prefix doesn't match */
         if ($this->prefix !== null && stripos($request->getUri(), $this->prefix) === false) {
             return false;
         }

--- a/src/Pecee/SimpleRouter/Route/RouteGroup.php
+++ b/src/Pecee/SimpleRouter/Route/RouteGroup.php
@@ -22,13 +22,14 @@ class RouteGroup extends Route implements IGroupRoute
             return true;
         }
 
-        foreach($this->domains as $domain) {
+        foreach ($this->domains as $domain) {
 
             $parameters = $this->parseParameters($domain, $request->getHost(), '.*');
 
             if ($parameters !== null && count($parameters) > 0) {
 
                 $this->parameters = $parameters;
+
                 return true;
             }
         }

--- a/src/Pecee/SimpleRouter/Route/RouteResource.php
+++ b/src/Pecee/SimpleRouter/Route/RouteResource.php
@@ -82,19 +82,19 @@ class RouteResource extends LoadableRoute implements IControllerRoute
         $url = rtrim($url, '/') . '/';
 
         /* Match global regular-expression for route */
-        if($this->matchRegex($request, $url) === true) {
-            return true;
+        $domainMatch = $this->matchRegex($request, $url);
+        if($domainMatch !== null) {
+            return $domainMatch;
         }
 
         $route = rtrim($this->url, '/') . '/{id?}/{action?}';
 
         $parameters = $this->parseParameters($route, $url);
-
         if ($parameters === null) {
             return false;
         }
 
-        $this->setParameters((array)$parameters);
+        $this->parameters = (array)$parameters;
 
         $action = isset($this->parameters['action']) ? $this->parameters['action'] : null;
         unset($this->parameters['action']);
@@ -107,7 +107,7 @@ class RouteResource extends LoadableRoute implements IControllerRoute
         }
 
         // Update
-        if (isset($this->parameters['id']) && in_array($method, [ static::REQUEST_TYPE_PATCH, static::REQUEST_TYPE_PUT ])) {
+        if (isset($this->parameters['id']) && in_array($method, [ static::REQUEST_TYPE_PATCH, static::REQUEST_TYPE_PUT ], false)) {
             return $this->call($this->methodNames['update']);
         }
 

--- a/src/Pecee/SimpleRouter/Route/RouteResource.php
+++ b/src/Pecee/SimpleRouter/Route/RouteResource.php
@@ -83,7 +83,7 @@ class RouteResource extends LoadableRoute implements IControllerRoute
 
         /* Match global regular-expression for route */
         $domainMatch = $this->matchRegex($request, $url);
-        if($domainMatch !== null) {
+        if ($domainMatch !== null) {
             return $domainMatch;
         }
 
@@ -107,7 +107,7 @@ class RouteResource extends LoadableRoute implements IControllerRoute
         }
 
         // Update
-        if (isset($this->parameters['id']) && in_array($method, [ static::REQUEST_TYPE_PATCH, static::REQUEST_TYPE_PUT ], false)) {
+        if (isset($this->parameters['id']) && in_array($method, [static::REQUEST_TYPE_PATCH, static::REQUEST_TYPE_PUT], false)) {
             return $this->call($this->methodNames['update']);
         }
 

--- a/src/Pecee/SimpleRouter/Route/RouteResource.php
+++ b/src/Pecee/SimpleRouter/Route/RouteResource.php
@@ -2,7 +2,6 @@
 namespace Pecee\SimpleRouter\Route;
 
 use Pecee\Http\Request;
-use Pecee\SimpleRouter\Exceptions\NotFoundHttpException;
 
 class RouteResource extends LoadableRoute implements IControllerRoute
 {
@@ -70,34 +69,9 @@ class RouteResource extends LoadableRoute implements IControllerRoute
         return $this->url;
     }
 
-    public function renderRoute(Request $request)
-    {
-        if ($this->getCallback() !== null && is_callable($this->getCallback())) {
-            // When the callback is a function
-            call_user_func_array($this->getCallback(), $this->getParameters());
-        } else {
-            // When the callback is a method
-            $controller = explode('@', $this->getCallback());
-            $className = $this->getNamespace() . '\\' . $controller[0];
-            $class = $this->loadClass($className);
-            $method = strtolower($controller[1]);
-
-            if (!method_exists($class, $method)) {
-                throw new NotFoundHttpException(sprintf('Method %s does not exist in class %s', $method, $className), 404);
-            }
-
-            call_user_func_array([$class, $method], $this->getParameters());
-
-            return $class;
-        }
-
-        return null;
-    }
-
-    protected function call($method, $parameters)
+    protected function call($method)
     {
         $this->setCallback($this->controller . '@' . $method);
-        $this->parameters = $parameters;
 
         return true;
     }
@@ -107,54 +81,58 @@ class RouteResource extends LoadableRoute implements IControllerRoute
         $url = parse_url(urldecode($request->getUri()), PHP_URL_PATH);
         $url = rtrim($url, '/') . '/';
 
+        /* Match global regular-expression for route */
+        if($this->matchRegex($request, $url) === true) {
+            return true;
+        }
+
         $route = rtrim($this->url, '/') . '/{id?}/{action?}';
 
         $parameters = $this->parseParameters($route, $url);
 
-        if ($parameters !== null) {
-
-            $parameters = array_merge($this->parameters, (array)$parameters);
-
-            $action = isset($parameters['action']) ? $parameters['action'] : null;
-            unset($parameters['action']);
-
-            $method = $request->getMethod();
-
-            // Delete
-            if ($method === static::REQUEST_TYPE_DELETE && isset($parameters['id'])) {
-                return $this->call($this->methodNames['destroy'], $parameters);
-            }
-
-            // Update
-            if (isset($parameters['id']) && in_array($method, [static::REQUEST_TYPE_PATCH, static::REQUEST_TYPE_PUT])) {
-                return $this->call($this->methodNames['update'], $parameters);
-            }
-
-            // Edit
-            if ($method === static::REQUEST_TYPE_GET && isset($parameters['id']) && strtolower($action) === 'edit') {
-                return $this->call($this->methodNames['edit'], $parameters);
-            }
-
-            // Create
-            if ($method === static::REQUEST_TYPE_GET && strtolower($action) === 'create') {
-                return $this->call($this->methodNames['create'], $parameters);
-            }
-
-            // Save
-            if ($method === static::REQUEST_TYPE_POST) {
-                return $this->call($this->methodNames['store'], $parameters);
-            }
-
-            // Show
-            if ($method === static::REQUEST_TYPE_GET && isset($parameters['id'])) {
-                return $this->call($this->methodNames['show'], $parameters);
-            }
-
-            // Index
-            return $this->call($this->methodNames['index'], $parameters);
+        if ($parameters === null) {
+            return false;
         }
 
-        return null;
+        $this->setParameters((array)$parameters);
+
+        $action = isset($this->parameters['action']) ? $this->parameters['action'] : null;
+        unset($this->parameters['action']);
+
+        $method = $request->getMethod();
+
+        // Delete
+        if ($method === static::REQUEST_TYPE_DELETE && isset($this->parameters['id'])) {
+            return $this->call($this->methodNames['destroy']);
+        }
+
+        // Update
+        if (isset($this->parameters['id']) && in_array($method, [ static::REQUEST_TYPE_PATCH, static::REQUEST_TYPE_PUT ])) {
+            return $this->call($this->methodNames['update']);
+        }
+
+        // Edit
+        if ($method === static::REQUEST_TYPE_GET && isset($this->parameters['id']) && strtolower($action) === 'edit') {
+            return $this->call($this->methodNames['edit']);
+        }
+
+        // Create
+        if ($method === static::REQUEST_TYPE_GET && strtolower($action) === 'create') {
+            return $this->call($this->methodNames['create']);
+        }
+
+        // Save
+        if ($method === static::REQUEST_TYPE_POST) {
+            return $this->call($this->methodNames['store']);
+        }
+
+        // Show
+        if ($method === static::REQUEST_TYPE_GET && isset($this->parameters['id'])) {
+            return $this->call($this->methodNames['show']);
+        }
+
+        // Index
+        return $this->call($this->methodNames['index']);
     }
 
     /**

--- a/src/Pecee/SimpleRouter/Route/RouteUrl.php
+++ b/src/Pecee/SimpleRouter/Route/RouteUrl.php
@@ -24,12 +24,13 @@ class RouteUrl extends LoadableRoute
 
         /* Make regular expression based on route */
         $parameters = $this->parseParameters($this->url, $url);
-        if($parameters !== null) {
-            $this->setParameters($parameters);
-            return true;
+        if($parameters === null) {
+            return false;
         }
 
-        return false;
+        $this->setParameters($parameters);
+
+        return true;
 
     }
 

--- a/src/Pecee/SimpleRouter/Route/RouteUrl.php
+++ b/src/Pecee/SimpleRouter/Route/RouteUrl.php
@@ -18,13 +18,13 @@ class RouteUrl extends LoadableRoute
 
         /* Match global regular-expression for route */
         $domainMatch = $this->matchRegex($request, $url);
-        if($domainMatch !== null) {
+        if ($domainMatch !== null) {
             return $domainMatch;
         }
 
         /* Make regular expression based on route */
         $parameters = $this->parseParameters($this->url, $url);
-        if($parameters === null) {
+        if ($parameters === null) {
             return false;
         }
 

--- a/src/Pecee/SimpleRouter/Route/RouteUrl.php
+++ b/src/Pecee/SimpleRouter/Route/RouteUrl.php
@@ -16,34 +16,24 @@ class RouteUrl extends LoadableRoute
         $url = parse_url(urldecode($request->getUri()), PHP_URL_PATH);
         $url = rtrim($url, '/') . '/';
 
-        // Match on custom defined regular expression
-        if ($this->regex !== null) {
-            $parameters = [];
-            if (preg_match($this->regex, $request->getHost() . $url, $parameters)) {
-                /* Remove global match */
-                if (count($parameters) > 1) {
-                    array_shift($parameters);
-                    $this->parameters = $parameters;
-                }
-
-                return true;
-            }
-
-            return null;
+        /* Match global regular-expression for route */
+        if($this->matchRegex($request, $url) === true) {
+            return true;
         }
 
-        // Make regular expression based on route
+        /* Make regular expression based on route */
         $route = rtrim($this->url, '/') . '/';
 
         $parameters = $this->parseParameters($route, $url);
 
         if ($parameters !== null) {
-            $this->parameters = array_merge($this->parameters, $parameters);
+            $this->setParameters($parameters);
+            //$this->parameters = array_merge($this->parameters, $parameters);
 
             return true;
         }
 
-        return null;
+        return false;
     }
 
 }

--- a/src/Pecee/SimpleRouter/Route/RouteUrl.php
+++ b/src/Pecee/SimpleRouter/Route/RouteUrl.php
@@ -17,8 +17,9 @@ class RouteUrl extends LoadableRoute
         $url = rtrim($url, '/') . '/';
 
         /* Match global regular-expression for route */
-        if($this->matchRegex($request, $url) === true) {
-            return true;
+        $domainMatch = $this->matchRegex($request, $url);
+        if($domainMatch !== null) {
+            return $domainMatch;
         }
 
         /* Make regular expression based on route */

--- a/src/Pecee/SimpleRouter/Route/RouteUrl.php
+++ b/src/Pecee/SimpleRouter/Route/RouteUrl.php
@@ -22,18 +22,14 @@ class RouteUrl extends LoadableRoute
         }
 
         /* Make regular expression based on route */
-        $route = rtrim($this->url, '/') . '/';
-
-        $parameters = $this->parseParameters($route, $url);
-
-        if ($parameters !== null) {
+        $parameters = $this->parseParameters($this->url, $url);
+        if($parameters !== null) {
             $this->setParameters($parameters);
-            //$this->parameters = array_merge($this->parameters, $parameters);
-
             return true;
         }
 
         return false;
+
     }
 
 }

--- a/src/Pecee/SimpleRouter/Router.php
+++ b/src/Pecee/SimpleRouter/Router.php
@@ -167,7 +167,7 @@ class Router
                     $route->renderRoute($this->request);
                     $this->processingRoute = false;
 
-                    if ($route->matchRoute($this->request)) {
+                    if ($route->matchRoute($this->request) === true) {
 
                         /* Add exception handlers */
                         if (count($route->getExceptionHandlers()) > 0) {
@@ -220,7 +220,6 @@ class Router
         $routeNotAllowed = false;
 
         try {
-
             /* Initialize boot-managers */
             if (count($this->bootManagers) > 0) {
 
@@ -246,7 +245,7 @@ class Router
 
                 if ($this->csrfVerifier !== null) {
 
-                    // Verify csrf token for request
+                    /* Verify csrf token for request */
                     $this->csrfVerifier->handle($this->request);
                 }
 
@@ -261,10 +260,10 @@ class Router
                 $route = $this->processedRoutes[$i];
 
                 /* If the route matches */
-                if ($route->matchRoute($this->request)) {
+                if ($route->matchRoute($this->request) === true) {
 
                     /* Check if request method matches */
-                    if (count($route->getRequestMethods()) > 0 && in_array($this->request->getMethod(), $route->getRequestMethods()) === false) {
+                    if (count($route->getRequestMethods()) > 0 && in_array($this->request->getMethod(), $route->getRequestMethods(), false) === false) {
                         $routeNotAllowed = true;
                         continue;
                     }

--- a/test/RouterRouteTest.php
+++ b/test/RouterRouteTest.php
@@ -14,6 +14,26 @@ class RouterRouteTest extends PHPUnit_Framework_TestCase
 {
     protected $result = false;
 
+    public function testMultiParam()
+    {
+        SimpleRouter::router()->reset();
+        SimpleRouter::request()->setMethod('get');
+        SimpleRouter::request()->setUri('/test-param1-param2');
+
+        SimpleRouter::get('/test-{param1}-{param2}', function($param1, $param2) {
+
+            if($param1 === 'param1' && $param2 === 'param2') {
+                $this->result = true;
+            }
+
+        });
+
+        SimpleRouter::start();
+
+        $this->assertTrue($this->result);
+
+    }
+
     /**
      * Redirects to another route through 3 exception handlers.
      *
@@ -115,16 +135,6 @@ class RouterRouteTest extends PHPUnit_Framework_TestCase
         SimpleRouter::request()->setUri('/test-param1');
 
         SimpleRouter::get('/test-{param1}', 'DummyController@param');
-        SimpleRouter::start();
-    }
-
-    public function testMultiParam()
-    {
-        SimpleRouter::router()->reset();
-        SimpleRouter::request()->setMethod('get');
-        SimpleRouter::request()->setUri('/test-param1-param2');
-
-        SimpleRouter::get('/test-{param1}-{param2}', 'DummyController@param');
         SimpleRouter::start();
     }
 


### PR DESCRIPTION
- Newly rewritten, simplified url-match behavior.
- Moved match/regex functionality from `Route` to `RouteLoadable` where it belongs.
- Moved `loadClass` to `Route`.
- It's now possible to chose if nullable parameters should be passed on to the Controller by overwriting the `$filterEmptyParams` property.
- Improved parameter-handling.
- Added global reg-ex match to all routes (no longer only `RouteUrl`).
- Moved `renderRoute` to `Route` - no need in written the same code everywhere.
- Simplified `PARAMETERS_REGEX_MATCH`-regex in `Route` class.
- Bug fixes and general improvements.