### PR TITLE
Development

### DIFF
--- a/src/Pecee/Http/Request.php
+++ b/src/Pecee/Http/Request.php
@@ -237,15 +237,22 @@ class Request
     {
         $this->rewriteRoute = $route;
 
-        $namespace = SimpleRouter::getDefaultNamespace();
+        $callback = $route->getCallback();
 
-        if ($namespace !== null) {
+        /* Only add default namespace on relative callbacks */
+        if($callback === null || $callback[0] !== '\\') {
 
-            if ($this->rewriteRoute->getNamespace() !== null) {
-                $namespace .= '\\' . $this->rewriteRoute->getNamespace();
+            $namespace = SimpleRouter::getDefaultNamespace();
+
+            if ($namespace !== null) {
+
+                if ($this->rewriteRoute->getNamespace() !== null) {
+                    $namespace .= '\\' . $this->rewriteRoute->getNamespace();
+                }
+
+                $this->rewriteRoute->setDefaultNamespace($namespace);
+
             }
-
-            $this->rewriteRoute->setDefaultNamespace($namespace);
 
         }
 

--- a/src/Pecee/SimpleRouter/Route/LoadableRoute.php
+++ b/src/Pecee/SimpleRouter/Route/LoadableRoute.php
@@ -27,9 +27,9 @@ abstract class LoadableRoute extends Route implements ILoadableRoute
      */
     public function loadMiddleware(Request $request)
     {
-        if (count($this->getMiddlewares()) > 0) {
+        $max = count($this->getMiddlewares());
 
-            $max = count($this->getMiddlewares());
+        if ($max > 0) {
 
             for ($i = 0; $i < $max; $i++) {
 
@@ -37,7 +37,7 @@ abstract class LoadableRoute extends Route implements ILoadableRoute
 
                 $middleware = $this->loadClass($middleware);
 
-                if (!($middleware instanceof IMiddleware)) {
+                if (($middleware instanceof IMiddleware) === false) {
                     throw new HttpException($middleware . ' must be instance of Middleware');
                 }
 
@@ -48,7 +48,6 @@ abstract class LoadableRoute extends Route implements ILoadableRoute
 
     public function matchRegex(Request $request, $url)
     {
-
         /* Match on custom defined regular expression */
 
         if ($this->regex === null) {

--- a/src/Pecee/SimpleRouter/Route/Route.php
+++ b/src/Pecee/SimpleRouter/Route/Route.php
@@ -57,16 +57,21 @@ abstract class Route implements IRoute
 
     public function renderRoute(Request $request)
     {
-        if ($this->getCallback() !== null && is_callable($this->getCallback())) {
+        $callback = $this->getCallback();
+
+        if ($callback !== null && is_callable($callback)) {
 
             /* When the callback is a function */
-            call_user_func_array($this->getCallback(), $this->getParameters());
+            call_user_func_array($callback, $this->getParameters());
 
         } else {
 
             /* When the callback is a method */
-            $controller = explode('@', $this->getCallback());
-            $className = $this->getNamespace() . '\\' . $controller[0];
+            $controller = explode('@', $callback);
+
+            $namespace = $this->getNamespace();
+
+            $className = ($namespace !== null) ? $namespace . '\\' . $controller[0] : $controller[0];
 
             $class = $this->loadClass($className);
             $method = $controller[1];

--- a/src/Pecee/SimpleRouter/Router.php
+++ b/src/Pecee/SimpleRouter/Router.php
@@ -340,7 +340,7 @@ class Router
 
             if ($includeEmpty === false) {
                 $getParams = array_filter($getParams, function ($item) {
-                    return (trim($item) !== false);
+                    return (trim($item) !== '');
                 });
             }
 

--- a/src/Pecee/SimpleRouter/SimpleRouter.php
+++ b/src/Pecee/SimpleRouter/SimpleRouter.php
@@ -284,6 +284,7 @@ class SimpleRouter
     public static function resource($url, $controller, array $settings = null)
     {
         $route = new RouteResource($url, $controller);
+        $route = static::addDefaultNamespace($route);
 
         if ($settings !== null) {
             $route->setSettings($settings);
@@ -360,13 +361,23 @@ class SimpleRouter
     protected static function addDefaultNamespace(IRoute $route)
     {
         if (static::$defaultNamespace !== null) {
-            $namespace = static::$defaultNamespace;
 
-            if ($route->getNamespace() !== null) {
-                $namespace .= '\\' . $route->getNamespace();
+            $callback = $route->getCallback();
+
+            /* Only add default namespace on relative callbacks */
+            if($callback === null || $callback[0] !== '\\') {
+
+                $namespace = static::$defaultNamespace;
+
+                $currentNamespace = $route->getNamespace();
+
+                if ($currentNamespace !== null) {
+                    $namespace .= '\\' . $currentNamespace;
+                }
+
+                $route->setDefaultNamespace($namespace);
+
             }
-
-            $route->setDefaultNamespace($namespace);
         }
 
         return $route;


### PR DESCRIPTION
- Fixed: only set default namespace on relative callbacks.
- Fixed: default-namespace not being set when calling `SimpleRouter::resource`.
- Minor optimisations.