### PR TITLE
Bugfix urlmatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ If you want a great new feature or experience any issues what-so-ever, please fe
 		- [Optional parameters](#optional-parameters)
 		- [Regular expression constraints](#regular-expression-constraints)
 		- [Regular expression route-match](#regular-expression-route-match)
+		- [Custom regex for matching parameters](#custom-regex-for-matching-parameters)
 	- [Named routes](#named-routes)
 		- [Generating URLs To Named Routes](#generating-urls-to-named-routes)
 	- [Router groups](#router-groups)
@@ -381,7 +382,7 @@ The example below is using the following regular expression: `/ajax/([\w]+)/?([0
 
 **Matches:** `/ajax/abc/`, `/ajax/abc/123/`
 
-**Doesn't match:** `/ajax/`
+**Won't match:** `/ajax/`
 
 Match groups specified in the regex will be passed on as parameters:
 
@@ -390,6 +391,35 @@ SimpleRouter::all('/ajax/abc/123', function($param1, $param2) {
 	// param1 = abc
 	// param2 = 123
 })->setMatch('/\/ajax\/([\w]+)\/?([0-9]+)?\/?/is');
+```
+
+### Custom regex for matching parameters
+
+By default simple-php-router uses the `\w` regular expression when matching parameters. 
+This decision was made with speed and reliability in mind, as this match will match both letters, number and most of the used symbols on the internet.
+
+However, sometimes it can be necessary to add a custom regular expression to match more advanced characters like `-` etc. 
+
+Instead of adding a custom regular expression to all your parameters, you can simply add a global regular expression which will be used on all the parameters on the route. 
+
+**Note:** If you the regular expression to be available across, we recommend using the global parameter on a group as demonstrated in the examples below.
+
+#### Example
+
+This example will ensure that all parameters use the `[\w\-]+` regular expression when parsing.
+
+```php
+SimpleRouter::get('/path/{parameter}', 'VideoController@home', ['defaultParameterRegex' => '[\w\-]+']);
+```
+
+You can also apply this setting to a group if you need multiple routes to use your custom regular expression when parsing parameters.
+
+```php
+SimpleRouter::group(['defaultParameterRegex' => '[\w\-]+'], function() {
+
+    SimpleRouter::get('/path/{parameter}', 'VideoController@home');
+
+});
 ```
 
 ## Named routes
@@ -1101,35 +1131,6 @@ $router->addRoute($route);
 ## Parameters
 
 This section contains advanced tips & tricks on extending the usage for parameters.
-
-### Custom default regex for matching parameters
-
-By default simple-php-router uses the `\w` regular expression when matching parameters. 
-This decision was made with speed and reliability in mind, as this match will match both letters, number and most of the used symbols on the internet.
-
-However, sometimes it can be nessesary to add a custom regular expression to match more advanced characters like `-` etc. 
-
-Instead of adding a custom regular expression to all your parameters, you can simply add a global regular expression which will be used on all the parameters on the route. 
-
-**Note:** If you the regular expression to be available across, we recommend using the global parameter on a group as demonstrated in the examples below.
-
-#### Route
-
-This example will ensure that all parameters use the `[\w\-]+` regular expression when parsing.
-
-```php
-SimpleRouter::get('/path/{parameter}', 'VideoController@home', ['defaultParameterRegex' => '[\w\-]+']);
-```
-
-You can also apply this setting to a group if you need multiple routes to use your custom regular expression when parsing parameters.
-
-```php
-SimpleRouter::group(['defaultParameterRegex' => '[\w\-]+'], function() {
-
-    SimpleRouter::get('/path/{parameter}', 'VideoController@home');
-
-});
-```
 
 ## Extending
 

--- a/src/Pecee/SimpleRouter/Route/Route.php
+++ b/src/Pecee/SimpleRouter/Route/Route.php
@@ -110,6 +110,7 @@ abstract class Route implements IRoute
 
         $parameters = [];
 
+        // Ensures that hostnames/domains will work with parameters
         $url = '/' . ltrim($url, '/');
 
         if (preg_match_all('/' . $regex . '/', $route, $parameters)) {

--- a/src/Pecee/SimpleRouter/Route/Route.php
+++ b/src/Pecee/SimpleRouter/Route/Route.php
@@ -135,7 +135,7 @@ abstract class Route implements IRoute
                         }
                     }
 
-                    $regex = sprintf('\-?\/?(?P<%s>%s)', $name, $regex) . $parameters[2][$key];
+                    $regex = sprintf('(?:\/|\-)' . $parameters[2][$key] . '(?P<%s>%s)', $name, $regex) . $parameters[2][$key];
 
                 }
 
@@ -148,7 +148,9 @@ abstract class Route implements IRoute
             $urlRegex = preg_quote($route, '/');
         }
 
-        if (preg_match('/^' . $urlRegex . '(\/?)$/', $url, $matches) > 0) {
+        echo $urlRegex . '\/? | ' . $url . chr(10);
+
+        if (preg_match('/^' . $urlRegex . '\/?/', $url, $matches) > 0) {
 
             $values = [];
 

--- a/src/Pecee/SimpleRouter/Route/Route.php
+++ b/src/Pecee/SimpleRouter/Route/Route.php
@@ -110,6 +110,8 @@ abstract class Route implements IRoute
 
         $parameters = [];
 
+        $url = '/' . ltrim($url, '/');
+
         if (preg_match_all('/' . $regex . '/', $route, $parameters)) {
 
             $urlParts = preg_split('/((\-?\/?)\{[^}]+\})/', rtrim($route, '/'));
@@ -147,8 +149,6 @@ abstract class Route implements IRoute
         } else {
             $urlRegex = preg_quote($route, '/');
         }
-
-        echo $urlRegex . '\/? | ' . $url . chr(10);
 
         if (preg_match('/^' . $urlRegex . '\/?/', $url, $matches) > 0) {
 

--- a/src/Pecee/SimpleRouter/Route/RouteController.php
+++ b/src/Pecee/SimpleRouter/Route/RouteController.php
@@ -53,7 +53,7 @@ class RouteController extends LoadableRoute implements IControllerRoute
         if (strpos($name, '.') !== false) {
             $found = array_search(substr($name, strrpos($name, '.') + 1), $this->names, false);
             if ($found !== false) {
-                $method = $found;
+                $method = (string)$found;
             }
         }
 

--- a/src/Pecee/SimpleRouter/Router.php
+++ b/src/Pecee/SimpleRouter/Router.php
@@ -11,6 +11,7 @@ use Pecee\SimpleRouter\Route\IControllerRoute;
 use Pecee\SimpleRouter\Route\IGroupRoute;
 use Pecee\SimpleRouter\Route\ILoadableRoute;
 use Pecee\SimpleRouter\Route\IRoute;
+use Pecee\SimpleRouter\Route\LoadableRoute;
 
 class Router
 {
@@ -123,6 +124,8 @@ class Router
         $exceptionHandlers = [];
 
         $url = ($this->request->getRewriteUrl() !== null) ? $this->request->getRewriteUrl() : $this->request->getUri();
+
+
 
         /* @var $route IRoute */
         for ($i = $max; $i >= 0; $i--) {

--- a/src/Pecee/SimpleRouter/Router.php
+++ b/src/Pecee/SimpleRouter/Router.php
@@ -11,7 +11,6 @@ use Pecee\SimpleRouter\Route\IControllerRoute;
 use Pecee\SimpleRouter\Route\IGroupRoute;
 use Pecee\SimpleRouter\Route\ILoadableRoute;
 use Pecee\SimpleRouter\Route\IRoute;
-use Pecee\SimpleRouter\Route\LoadableRoute;
 
 class Router
 {
@@ -124,8 +123,6 @@ class Router
         $exceptionHandlers = [];
 
         $url = ($this->request->getRewriteUrl() !== null) ? $this->request->getRewriteUrl() : $this->request->getUri();
-
-
 
         /* @var $route IRoute */
         for ($i = $max; $i >= 0; $i--) {

--- a/test/RouterUrlTest.php
+++ b/test/RouterUrlTest.php
@@ -10,24 +10,22 @@ class RouterUrlTest extends PHPUnit_Framework_TestCase
 
     public function testOptionalParameters()
     {
-
-        // TestRouter::get('/aviso/legal', 'DummyController@method1');
+        TestRouter::get('/aviso/legal', 'DummyController@method1');
         TestRouter::get('/aviso/{aviso}', 'DummyController@method1');
-        //TestRouter::get('/pagina/{pagina}', 'DummyController@method1');
+        TestRouter::get('/pagina/{pagina}', 'DummyController@method1');
         TestRouter::get('/{pagina?}', 'DummyController@method1');
 
-        //TestRouter::debugNoReset('/aviso/optional', 'get');
-        //$this->assertEquals('/aviso/{aviso}/', TestRouter::router()->getRequest()->getLoadedRoute()->getUrl());
+        TestRouter::debugNoReset('/aviso/optional', 'get');
+        $this->assertEquals('/aviso/{aviso}/', TestRouter::router()->getRequest()->getLoadedRoute()->getUrl());
 
-        //TestRouter::debugNoReset('/pagina/optional', 'get');
-        //$this->assertEquals('/pagina/{pagina}/', TestRouter::router()->getRequest()->getLoadedRoute()->getUrl());
+        TestRouter::debugNoReset('/pagina/optional', 'get');
+        $this->assertEquals('/pagina/{pagina}/', TestRouter::router()->getRequest()->getLoadedRoute()->getUrl());
 
-        //TestRouter::debugNoReset('/optional', 'get');
-        //$this->assertEquals('/{pagina?}/', TestRouter::router()->getRequest()->getLoadedRoute()->getUrl());
+        TestRouter::debugNoReset('/optional', 'get');
+        $this->assertEquals('/{pagina?}/', TestRouter::router()->getRequest()->getLoadedRoute()->getUrl());
 
-// New test lines
-        //TestRouter::debugNoReset('/avisolegal', 'get');
-        //$this->assertNotEquals('/aviso/{aviso}/', TestRouter::router()->getRequest()->getLoadedRoute()->getUrl());
+        TestRouter::debugNoReset('/avisolegal', 'get');
+        $this->assertNotEquals('/aviso/{aviso}/', TestRouter::router()->getRequest()->getLoadedRoute()->getUrl());
 
         TestRouter::debugNoReset('/avisolegal', 'get');
         $this->assertEquals('/{pagina?}/', TestRouter::router()->getRequest()->getLoadedRoute()->getUrl());

--- a/test/RouterUrlTest.php
+++ b/test/RouterUrlTest.php
@@ -8,6 +8,33 @@ require_once 'Helpers/TestRouter.php';
 class RouterUrlTest extends PHPUnit_Framework_TestCase
 {
 
+    public function testOptionalParameters()
+    {
+
+        // TestRouter::get('/aviso/legal', 'DummyController@method1');
+        TestRouter::get('/aviso/{aviso}', 'DummyController@method1');
+        //TestRouter::get('/pagina/{pagina}', 'DummyController@method1');
+        TestRouter::get('/{pagina?}', 'DummyController@method1');
+
+        //TestRouter::debugNoReset('/aviso/optional', 'get');
+        //$this->assertEquals('/aviso/{aviso}/', TestRouter::router()->getRequest()->getLoadedRoute()->getUrl());
+
+        //TestRouter::debugNoReset('/pagina/optional', 'get');
+        //$this->assertEquals('/pagina/{pagina}/', TestRouter::router()->getRequest()->getLoadedRoute()->getUrl());
+
+        //TestRouter::debugNoReset('/optional', 'get');
+        //$this->assertEquals('/{pagina?}/', TestRouter::router()->getRequest()->getLoadedRoute()->getUrl());
+
+// New test lines
+        //TestRouter::debugNoReset('/avisolegal', 'get');
+        //$this->assertNotEquals('/aviso/{aviso}/', TestRouter::router()->getRequest()->getLoadedRoute()->getUrl());
+
+        TestRouter::debugNoReset('/avisolegal', 'get');
+        $this->assertEquals('/{pagina?}/', TestRouter::router()->getRequest()->getLoadedRoute()->getUrl());
+
+        TestRouter::router()->reset();
+    }
+
     public function testSimilarUrls()
     {
         // Match normal route on alias


### PR DESCRIPTION
- Moved "Custom regex for matching parameters" to "Route parameters" in documentation (based on issue #249).
- Fixed mismatched routes: `/testing` matching `/test/{anything}` (issue: #248).