### PR TITLE
Fixes and development

### DIFF
--- a/src/Pecee/SimpleRouter/Route/LoadableRoute.php
+++ b/src/Pecee/SimpleRouter/Route/LoadableRoute.php
@@ -92,7 +92,7 @@ abstract class LoadableRoute extends Route implements ILoadableRoute
      * Used when calling the url() helper.
      *
      * @param string|null $method
-     * @param array|null $parameters
+     * @param string|array|null $parameters
      * @param string|null $name
      * @return string
      */
@@ -123,7 +123,11 @@ abstract class LoadableRoute extends Route implements ILoadableRoute
 
         for ($i = $max; $i >= 0; $i--) {
             $param = $keys[$i];
-            $value = $value = ($parameters !== null && array_key_exists($param, $parameters)) ? $parameters[$param] : $params[$param];
+
+            if($parameters !== null) {
+                $parameters = (array)$parameters;
+                $value = array_key_exists($param, $parameters) ? $parameters[$param] : $params[$param];
+            }
 
             /* If parameter is specifically set to null - use the original-defined value */
             if ($value === null && isset($this->originalParameters[$param])) {

--- a/src/Pecee/SimpleRouter/Route/Route.php
+++ b/src/Pecee/SimpleRouter/Route/Route.php
@@ -76,9 +76,7 @@ abstract class Route implements IRoute
         if (is_callable($callback) === true) {
 
             /* When the callback is a function */
-            call_user_func_array($callback, $this->getParameters());
-
-            return;
+            return call_user_func_array($callback, $this->getParameters());
 
         }
 
@@ -106,7 +104,7 @@ abstract class Route implements IRoute
             });
         }
 
-        call_user_func_array([$class, $method], $parameters);
+        return call_user_func_array([$class, $method], $parameters);
     }
 
     protected function parseParameters($route, $url, $parameterRegex = null)

--- a/src/Pecee/SimpleRouter/Router.php
+++ b/src/Pecee/SimpleRouter/Router.php
@@ -248,9 +248,7 @@ class Router
 
                     if ($rewriteRoute !== null) {
                         $rewriteRoute->loadMiddleware($this->request);
-                        $rewriteRoute->renderRoute($this->request);
-
-                        return;
+                        return $rewriteRoute->renderRoute($this->request);
                     }
 
                     /* If the request has changed */
@@ -267,7 +265,7 @@ class Router
                     /* Render route */
                     $routeNotAllowed = false;
                     $this->request->setLoadedRoute($route);
-                    $route->renderRoute($this->request);
+                    return $route->renderRoute($this->request);
 
                     break;
                 }
@@ -295,6 +293,11 @@ class Router
         }
     }
 
+    /**
+     * @param \Exception $e
+     * @throws HttpException
+     * @throws \Exception
+     */
     protected function handleException(\Exception $e)
     {
         $url = ($this->request->getRewriteUrl() !== null) ? $this->request->getRewriteUrl() : $this->request->getUri();
@@ -320,9 +323,7 @@ class Router
 
                 if ($rewriteRoute !== null) {
                     $rewriteRoute->loadMiddleware($this->request);
-                    $rewriteRoute->renderRoute($this->request);
-
-                    return;
+                    return $rewriteRoute->renderRoute($this->request);
                 }
 
                 $rewriteUrl = $this->request->getRewriteUrl();

--- a/src/Pecee/SimpleRouter/SimpleRouter.php
+++ b/src/Pecee/SimpleRouter/SimpleRouter.php
@@ -49,7 +49,7 @@ class SimpleRouter
      */
     public static function start()
     {
-        static::router()->routeRequest();
+        echo static::router()->routeRequest();
     }
 
     /**

--- a/test/RouterUrlTest.php
+++ b/test/RouterUrlTest.php
@@ -12,12 +12,18 @@ class RouterUrlTest extends PHPUnit_Framework_TestCase
     {
         TestRouter::get('/', 'DummyController@method1');
         TestRouter::get('/page/{id?}', 'DummyController@method1');
+        TestRouter::get('/test-output', function() {
+            return 'return value';
+        });
 
         TestRouter::debugNoReset('/page/22', 'get');
         $this->assertEquals('/page/{id?}/', TestRouter::router()->getRequest()->getLoadedRoute()->getUrl());
 
         TestRouter::debugNoReset('/', 'get');
         $this->assertEquals('/', TestRouter::router()->getRequest()->getLoadedRoute()->getUrl());
+
+        $output = TestRouter::debugOutput('/test-output', 'get');
+        $this->assertEquals('return value', $output);
 
         TestRouter::router()->reset();
     }


### PR DESCRIPTION
- `$parameter` argument in `findUrl` method now supports both `string`, `array` and `null` values to avoid any confusion. `url()` can now be called like this if only one parameter is present `url('method', 'parameter');` and `url('method', ['parameter1', 'parameter2']);` for multiple parameters.

- Using return value in callbacks now displays the value correctly (issue: #257)
- Added unit-tests for issue: #257 