### PR TITLE
V3 development

### DIFF
--- a/src/Pecee/SimpleRouter/Route/LoadableRoute.php
+++ b/src/Pecee/SimpleRouter/Route/LoadableRoute.php
@@ -124,14 +124,16 @@ abstract class LoadableRoute extends Route implements ILoadableRoute
         for ($i = $max; $i >= 0; $i--) {
             $param = $keys[$i];
 
-            if($parameters !== null) {
-                $parameters = (array)$parameters;
-                $value = array_key_exists($param, $parameters) ? $parameters[$param] : $params[$param];
-            }
+            if ($parameters === '' || (is_array($parameters) && count($parameters) === 0)) {
+                $value = '';
+            } else {
+                $p = (array)$parameters;
+                $value = array_key_exists($param, $p) ? $p[$param] : $params[$param];
 
-            /* If parameter is specifically set to null - use the original-defined value */
-            if ($value === null && isset($this->originalParameters[$param])) {
-                $value = $this->originalParameters[$param];
+                /* If parameter is specifically set to null - use the original-defined value */
+                if ($value === null && isset($this->originalParameters[$param])) {
+                    $value = $this->originalParameters[$param];
+                }
             }
 
             if (stripos($url, $param1) !== false || stripos($url, $param) !== false) {

--- a/src/Pecee/SimpleRouter/Route/LoadableRoute.php
+++ b/src/Pecee/SimpleRouter/Route/LoadableRoute.php
@@ -144,6 +144,7 @@ abstract class LoadableRoute extends Route implements ILoadableRoute
             }
         }
 
+        $url = '/' . ltrim($url, '/');
         $url .= join('/', $unknownParams);
 
         return rtrim($url, '/') . '/';

--- a/test/RouterUrlTest.php
+++ b/test/RouterUrlTest.php
@@ -28,6 +28,21 @@ class RouterUrlTest extends PHPUnit_Framework_TestCase
         TestRouter::router()->reset();
     }
 
+    public function testUnicodeCharacters()
+    {
+        // Test spanish characters
+        TestRouter::get('/cursos/listado/{listado?}/{category?}', 'DummyController@method1', ['defaultParameterRegex' => '[\w\p{L}\s-]+']);
+        TestRouter::debugNoReset('/cursos/listado/especialidad/cirugía local', 'get');
+        $this->assertEquals('/cursos/listado/{listado?}/{category?}/', TestRouter::router()->getRequest()->getLoadedRoute()->getUrl());
+
+        // Test danish characters
+        TestRouter::get('/kategori/økse', 'DummyController@method1', ['defaultParameterRegex' => '[\w\ø]+']);
+        TestRouter::debugNoReset('/kategori/økse', 'get');
+        $this->assertEquals('/kategori/økse/', TestRouter::router()->getRequest()->getLoadedRoute()->getUrl());
+
+        TestRouter::router()->reset();
+    }
+
     public function testOptionalParameters()
     {
         TestRouter::get('/aviso/legal', 'DummyController@method1');


### PR DESCRIPTION
- Fixed using empty value in `url` still parsing current parameters.
- Fixed double `/` when calling `findUrl` on routes with the first parameter optional.
