### PR TITLE
Version 3.4.5.5

### DIFF
--- a/src/Pecee/SimpleRouter/SimpleRouter.php
+++ b/src/Pecee/SimpleRouter/SimpleRouter.php
@@ -427,7 +427,7 @@ class SimpleRouter
             $callback = $route->getCallback();
 
             /* Only add default namespace on relative callbacks */
-            if ($callback === null || $callback[0] !== '\\') {
+            if ($callback === null || (is_string($callback) === true && $callback[0] !== '\\')) {
 
                 $namespace = static::$defaultNamespace;
 


### PR DESCRIPTION
- Fixed default-namespace causing router to break on closures.
- Fixed spelling in documentation.