### PR TITLE
Version 3.4.9.0

### DIFF
--- a/src/Pecee/Http/Response.php
+++ b/src/Pecee/Http/Response.php
@@ -95,7 +95,7 @@ class Response
             throw new \InvalidArgumentException('Invalid type for parameter "value". Must be of type array or object implementing the \JsonSerializable interface.');
         }
 
-        $this->header('Content-type: application/json');
+        $this->header('Content-Type: application/json; charset=utf-8');
         echo json_encode($value, $options, $dept);
         exit(0);
     }


### PR DESCRIPTION
- Fixed utf-8 header issue for `response()->json()` method (issue: #333).