### PR TITLE
Version 3.4.9.2

### DIFF
--- a/src/Pecee/Http/Request.php
+++ b/src/Pecee/Http/Request.php
@@ -309,7 +309,7 @@ class Request
 
     public function __get($name)
     {
-        return $this->data[$name];
+        return isset($this->data[$name]) ? $this->data[$name] : null;
     }
 
 }

--- a/src/Pecee/Http/Request.php
+++ b/src/Pecee/Http/Request.php
@@ -309,7 +309,7 @@ class Request
 
     public function __get($name)
     {
-        return isset($this->data[$name]) ? $this->data[$name] : null;
+        return $this->data[$name];
     }
 
 }

--- a/src/Pecee/Http/Request.php
+++ b/src/Pecee/Http/Request.php
@@ -196,10 +196,14 @@ class Request
     }
 
     /**
-     * @param Uri $uri
+     * @param Uri|string $uri
      */
-    public function setUri(Uri $uri)
+    public function setUri($uri)
     {
+        if (is_string($uri) === true) {
+            $uri = new Uri($uri);
+        }
+
         $this->uri = $uri;
     }
 


### PR DESCRIPTION
- Compatibility: `setUri` in `Request` object can be both `string` and `Uri`.