### PR TITLE
Version 3.4.11.1

### DIFF
--- a/src/Pecee/Http/Response.php
+++ b/src/Pecee/Http/Response.php
@@ -37,12 +37,12 @@ class Response
         }
 
         $this->header('location: ' . $url);
-        die();
+        exit(0);
     }
 
     public function refresh()
     {
-        $this->redirect($this->request->getUri()->getPath());
+        $this->redirect($this->request->getUri()->getOriginalUrl());
     }
 
     /**


### PR DESCRIPTION
`Response` class: fixed `response()->refresh` not using correct original url (including hash parameters, querystrings etc).