### PR TITLE
Set HTTP method before initializing InputHandler

### DIFF
--- a/src/Pecee/Http/Request.php
+++ b/src/Pecee/Http/Request.php
@@ -84,7 +84,8 @@ class Request
 
         // Check if special IIS header exist, otherwise use default.
         $this->setUrl(new Url($this->getHeader('unencoded-url', $this->getHeader('request-uri'))));
-
+        
+        $this->method = strtolower($this->getHeader('request-method'));
         $this->inputHandler = new InputHandler($this);
         $this->method = strtolower($this->inputHandler->value('_method', $this->getHeader('request-method')));
     }


### PR DESCRIPTION
This is needed because without it the InputHandler doesn't know which http method is being used and because of that it can't parse the body of a PUT request.