### PR TITLE
Fix warning, because of wrong calculated cookie expiration timestamp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "RedooNetworks/simple-router",
+  "name": "pecee/simple-router",
   "description": "Simple, fast PHP router that is easy to get integrated and in almost any project. Heavily inspired by the Laravel router.",
   "keywords": [
     "router",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "pecee/simple-router",
+  "name": "RedooNetworks/simple-router",
   "description": "Simple, fast PHP router that is easy to get integrated and in almost any project. Heavily inspired by the Laravel router.",
   "keywords": [
     "router",

--- a/src/Pecee/Http/Security/CookieTokenProvider.php
+++ b/src/Pecee/Http/Security/CookieTokenProvider.php
@@ -63,7 +63,7 @@ class CookieTokenProvider implements ITokenProvider
     public function setToken(string $token): void
     {
         $this->token = $token;
-        setcookie(static::CSRF_KEY, $token, (time() + 60) * $this->cookieTimeoutMinutes, '/', ini_get('session.cookie_domain'), ini_get('session.cookie_secure'), ini_get('session.cookie_httponly'));
+        setcookie(static::CSRF_KEY, $token, time() + (60 * $this->cookieTimeoutMinutes), '/', ini_get('session.cookie_domain'), ini_get('session.cookie_secure'), ini_get('session.cookie_httponly'));
     }
 
     /**


### PR DESCRIPTION
There was a typo in calculation of Cookie Lifetime, so cookie do not have a valid expiration.
Also it should throw a warning in 32-bit PHP.

Normally not a real problem, but when security is a topic and explanation of every cookie is required, cookie should expire correctly.