### PR TITLE
Fix double slashes issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ ___
 
 # Getting started
 
-** THIS IS A FORK FROM skipperbent/simple-php-router, as the last commit from the original project is 2 years ago I decided to fork it, and merge the latest PRs from there **
+**THIS IS A FORK FROM skipperbent/simple-php-router, as the last commit from the original project is 2 years ago I decided to fork it, and merge the latest PRs from there**
 
 Add the latest version of the simple-router project running this command.
 

--- a/README.md
+++ b/README.md
@@ -113,10 +113,12 @@ ___
 
 # Getting started
 
+** THIS IS A FORK FROM skipperbent/simple-php-router, as the last commit from the original project is 2 years ago I decided to fork it, and merge the latest PRs from there **
+
 Add the latest version of the simple-router project running this command.
 
 ```
-composer require pecee/simple-router
+composer require eightsystems/simple-router
 ```
 
 ## Notes

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-  "name": "pecee/simple-router",
-  "description": "Simple, fast PHP router that is easy to get integrated and in almost any project. Heavily inspired by the Laravel router.",
+  "name": "eightsystems/simple-router",
+  "description": "Simple, fast PHP router that is easy to get integrated and in almost any project. Heavily inspired by the Laravel router. (Forked from skipperbent/simple-php-router)",
   "keywords": [
     "router",
     "router",
@@ -24,6 +24,10 @@
     {
       "name": "Simon Sessingø",
       "email": "simon.sessingoe@gmail.com"
+    },
+    {
+      "name": "Vin Souza",
+      "email": "vin@8sistemas.com"
     }
   ],
   "require": {

--- a/src/Pecee/Http/Url.php
+++ b/src/Pecee/Http/Url.php
@@ -393,7 +393,7 @@ class Url implements \JsonSerializable
 
         $parts = parse_url($encodedUrl, $component);
 
-	if ($parts === false) {
+        if ($parts === false) {
             //First try to normalize it, removing duplicate slashes, and if the problem still exists, we give the error
             $encodedUrl = preg_replace('#/+#','/',$encodedUrl);
             $parts = parse_url($encodedUrl, $component);

--- a/src/Pecee/Http/Url.php
+++ b/src/Pecee/Http/Url.php
@@ -393,8 +393,14 @@ class Url implements \JsonSerializable
 
         $parts = parse_url($encodedUrl, $component);
 
-        if ($parts === false) {
-            throw new MalformedUrlException(sprintf('Failed to parse url: "%s"', $url));
+	if ($parts === false) {
+            //First try to normalize it, removing duplicate slashes, and if the problem still exists, we give the error
+            $encodedUrl = preg_replace('#/+#','/',$encodedUrl);
+            $parts = parse_url($encodedUrl, $component);
+
+            if ($parts === false) {
+                throw new MalformedUrlException(sprintf('Failed to parse url: "%s"', $url));
+            }
         }
 
         return array_map('urldecode', $parts);


### PR DESCRIPTION
When a URL is requested with double slashes like "site.com//" it will fail with "URL can't be parsed", this will apply a simple fix to remove these double slashes in case this kind of issue happens.