### PR TITLE
get csrf token in request and test for prefix 'http-' in csrf token header

### DIFF
--- a/src/Pecee/Http/Middleware/BaseCsrfVerifier.php
+++ b/src/Pecee/Http/Middleware/BaseCsrfVerifier.php
@@ -68,7 +68,7 @@ class BaseCsrfVerifier implements IMiddleware
 
             $token = $request->getInputHandler()->value(
                 static::POST_KEY,
-                $request->getHeader(static::HEADER_KEY),
+                $request->getHeader(static::HEADER_KEY) ?? $request->getHeader('HTTP-' . static::HEADER_KEY),
                 'post'
             );
 

--- a/src/Pecee/Http/Middleware/BaseCsrfVerifier.php
+++ b/src/Pecee/Http/Middleware/BaseCsrfVerifier.php
@@ -64,7 +64,7 @@ class BaseCsrfVerifier implements IMiddleware
     public function handle(Request $request): void
     {
 
-        if ($this->skip($request) === false && \in_array($request->getMethod(), ['post', 'put', 'delete'], true) === true) {
+        if ($this->skip($request) === false && \in_array($request->getMethod(), ['post', 'put', 'patch', 'delete'], true) === true) {
 
             $token = $request->getInputHandler()->value(
                 static::POST_KEY,

--- a/src/Pecee/Http/Request.php
+++ b/src/Pecee/Http/Request.php
@@ -148,6 +148,15 @@ class Request
     }
 
     /**
+     * Get the csrf token
+     * @return string|null
+     */
+    public function getCsrfToken(): ?string
+    {
+        return $this->getHeader('x-csrf-token') ?? $this->getHeader('http-x-csrf-token');
+    }
+
+    /**
      * Get all headers
      * @return array
      */


### PR DESCRIPTION
Hello Simon,

as @mmdm95 mentioned in #491 in some requests php recieve the `x-csrf-token` with a `http-` prefix.
I also have to get the header using the `http-` preifx. I'm using the following method to set the header in js:
`jqxhr.setRequestHeader('X-CSRF-TOKEN', csrf_token);`
and recieve it in the `CsrfVerifier` using:
`$request->getHeader('HTTP-X-CSRF-TOKEN')`

In this commit I added a function to the `Request` that returns the `x-csrf-token` header with and without the `http-` prefix.
I also added this to the `BaseCsrfVerifier` in the `handle` function.

It is explained in [this stackoverflow post](https://stackoverflow.com/questions/541430/how-do-i-read-any-request-header-in-php#answer-541450):
> Meta-variables with names beginning with HTTP_ contain values read from the client request header fields, if the protocol used is HTTP. The HTTP header field name is converted to upper case, has all occurrences of - replaced with _ and has HTTP_ prepended to give the meta-variable name.

I'm not really sure why some people can recieve the header without the `http-` prefix, but I think it is better to add support.
I only added the `http-` prefix option as alternative and the non prefix one as original, because I think the header shoud not have this `http-` prefix.

~ Marius


Update:
I also added the `patch` method to the `BaseCsrfVerifier::handle` function.
Yes, the patch method does not contain any post parameters, but it will instantly fallback to the `defaultValue` and by that access the header.

~ Marius