### PR TITLE
Developer marius get csrf token

### DIFF
--- a/src/Pecee/Http/Input/InputHandler.php
+++ b/src/Pecee/Http/Input/InputHandler.php
@@ -28,6 +28,24 @@ class InputHandler
     protected $request;
 
     /**
+     * Original post variables
+     * @var array
+     */
+    protected $originalPost = [];
+
+    /**
+     * Original get variables
+     * @var array
+     */
+    protected $originalGet = [];
+
+    /**
+     * Get original file variables
+     * @var array
+     */
+    protected $originalFile = [];
+
+    /**
      * Input constructor.
      * @param Request $request
      */
@@ -46,22 +64,34 @@ class InputHandler
     {
         /* Parse get requests */
         if (\count($_GET) !== 0) {
-            $this->get = $this->parseInputItem($_GET);
+            $this->originalGet = $_GET;
+            $this->get = $this->parseInputItem($this->originalGet);
         }
 
         /* Parse post requests */
-        $postVars = $_POST;
+        $this->originalPost = $_POST;
 
-        if (\in_array($this->request->getMethod(), ['put', 'patch', 'delete'], false) === true) {
-            parse_str(file_get_contents('php://input'), $postVars);
+        if (\in_array($this->request->getMethod(), Request::$requestTypesPost, false) === true) {
+
+            $contents = file_get_contents('php://input');
+
+            // Append any PHP-input json
+            if (strpos(trim($contents), '{') === 0) {
+                $post = json_decode($contents, true);
+
+                if ($post !== false) {
+                    $this->originalPost += $post;
+                }
+            }
         }
 
-        if (\count($postVars) !== 0) {
-            $this->post = $this->parseInputItem($postVars);
+        if (\count($this->originalPost) !== 0) {
+            $this->post = $this->parseInputItem($this->originalPost);
         }
 
         /* Parse get requests */
         if (\count($_FILES) !== 0) {
+            $this->originalFile = $_FILES;
             $this->file = $this->parseFiles();
         }
     }
@@ -192,11 +222,11 @@ class InputHandler
     {
         $element = null;
 
-        if (\count($methods) === 0 || \in_array('get', $methods, true) === true) {
+        if (\count($methods) === 0 || \in_array(Request::REQUEST_TYPE_GET, $methods, true) === true) {
             $element = $this->get($index);
         }
 
-        if (($element === null && \count($methods) === 0) || (\count($methods) !== 0 && \in_array('post', $methods, true) === true)) {
+        if (($element === null && \count($methods) === 0) || (\count($methods) !== 0 && \in_array(Request::REQUEST_TYPE_POST, $methods, true) === true)) {
             $element = $this->post($index);
         }
 
@@ -288,24 +318,7 @@ class InputHandler
      */
     public function all(array $filter = []): array
     {
-        $output = $_GET;
-
-        if ($this->request->getMethod() === 'post') {
-
-            // Append POST data
-            $output += $_POST;
-            $contents = file_get_contents('php://input');
-
-            // Append any PHP-input json
-            if (strpos(trim($contents), '{') === 0) {
-                $post = json_decode($contents, true);
-
-                if ($post !== false) {
-                    $output += $post;
-                }
-            }
-        }
-
+        $output = $this->originalGet + $this->originalPost;
         $output = (\count($filter) > 0) ? array_intersect_key($output, array_flip($filter)) : $output;
 
         foreach ($filter as $filterKey) {

--- a/src/Pecee/Http/Middleware/BaseCsrfVerifier.php
+++ b/src/Pecee/Http/Middleware/BaseCsrfVerifier.php
@@ -63,13 +63,12 @@ class BaseCsrfVerifier implements IMiddleware
      */
     public function handle(Request $request): void
     {
-
-        if ($this->skip($request) === false && \in_array($request->getMethod(), ['post', 'put', 'patch', 'delete'], true) === true) {
+        if ($this->skip($request) === false && \in_array($request->getMethod(), Request::$requestTypesPost, true) === true) {
 
             $token = $request->getInputHandler()->value(
                 static::POST_KEY,
                 $request->getHeader(static::HEADER_KEY) ?? $request->getHeader('HTTP-' . static::HEADER_KEY),
-                'post'
+                Request::$requestTypesPost
             );
 
             if ($this->tokenProvider->validate((string)$token) === false) {
@@ -80,7 +79,6 @@ class BaseCsrfVerifier implements IMiddleware
 
         // Refresh existing token
         $this->tokenProvider->refresh();
-
     }
 
     public function getTokenProvider(): ITokenProvider

--- a/src/Pecee/Http/Request.php
+++ b/src/Pecee/Http/Request.php
@@ -10,6 +10,39 @@ use Pecee\SimpleRouter\SimpleRouter;
 
 class Request
 {
+    public const REQUEST_TYPE_GET = 'get';
+    public const REQUEST_TYPE_POST = 'post';
+    public const REQUEST_TYPE_PUT = 'put';
+    public const REQUEST_TYPE_PATCH = 'patch';
+    public const REQUEST_TYPE_OPTIONS = 'options';
+    public const REQUEST_TYPE_DELETE = 'delete';
+    public const REQUEST_TYPE_HEAD = 'head';
+
+    /**
+     * All request-types
+     * @var string[]
+     */
+    public static $requestTypes = [
+        self::REQUEST_TYPE_GET,
+        self::REQUEST_TYPE_POST,
+        self::REQUEST_TYPE_PUT,
+        self::REQUEST_TYPE_PATCH,
+        self::REQUEST_TYPE_OPTIONS,
+        self::REQUEST_TYPE_DELETE,
+        self::REQUEST_TYPE_HEAD,
+    ];
+
+    /**
+     * Post request-types.
+     * @var string[]
+     */
+    public static $requestTypesPost = [
+        self::REQUEST_TYPE_POST,
+        self::REQUEST_TYPE_PUT,
+        self::REQUEST_TYPE_PATCH,
+        self::REQUEST_TYPE_DELETE,
+    ];
+
     /**
      * Additional data
      *

--- a/src/Pecee/SimpleRouter/Route/Route.php
+++ b/src/Pecee/SimpleRouter/Route/Route.php
@@ -12,24 +12,6 @@ abstract class Route implements IRoute
     protected const PARAMETERS_REGEX_FORMAT = '%s([\w]+)(\%s?)%s';
     protected const PARAMETERS_DEFAULT_REGEX = '[\w\-]+';
 
-    public const REQUEST_TYPE_GET = 'get';
-    public const REQUEST_TYPE_POST = 'post';
-    public const REQUEST_TYPE_PUT = 'put';
-    public const REQUEST_TYPE_PATCH = 'patch';
-    public const REQUEST_TYPE_OPTIONS = 'options';
-    public const REQUEST_TYPE_DELETE = 'delete';
-    public const REQUEST_TYPE_HEAD = 'head';
-
-    public static $requestTypes = [
-        self::REQUEST_TYPE_GET,
-        self::REQUEST_TYPE_POST,
-        self::REQUEST_TYPE_PUT,
-        self::REQUEST_TYPE_PATCH,
-        self::REQUEST_TYPE_OPTIONS,
-        self::REQUEST_TYPE_DELETE,
-        self::REQUEST_TYPE_HEAD,
-    ];
-
     /**
      * If enabled parameters containing null-value
      * will not be passed along to the callback.
@@ -140,7 +122,7 @@ abstract class Route implements IRoute
             $urlRegex = preg_quote($route, '/');
         } else {
 
-            foreach (preg_split('/((\-?\/?)\{[^}]+\})/', $route) as $key => $t) {
+            foreach (preg_split('/((\-?\/?){[^}]+})/', $route) as $key => $t) {
 
                 $regex = '';
 

--- a/src/Pecee/SimpleRouter/Route/RouteController.php
+++ b/src/Pecee/SimpleRouter/Route/RouteController.php
@@ -64,7 +64,7 @@ class RouteController extends LoadableRoute implements IControllerRoute
         if ($method !== null) {
 
             /* Remove requestType from method-name, if it exists */
-            foreach (static::$requestTypes as $requestType) {
+            foreach (Request::$requestTypes as $requestType) {
 
                 if (stripos($method, $requestType) === 0) {
                     $method = (string)substr($method, \strlen($requestType));

--- a/src/Pecee/SimpleRouter/Route/RouteResource.php
+++ b/src/Pecee/SimpleRouter/Route/RouteResource.php
@@ -115,32 +115,32 @@ class RouteResource extends LoadableRoute implements IControllerRoute
         $method = $request->getMethod();
 
         // Delete
-        if ($method === static::REQUEST_TYPE_DELETE && $id !== null) {
+        if ($method === Request::REQUEST_TYPE_DELETE && $id !== null) {
             return $this->call($this->methodNames['destroy']);
         }
 
         // Update
-        if ($id !== null && \in_array($method, [static::REQUEST_TYPE_PATCH, static::REQUEST_TYPE_PUT], true) === true) {
+        if ($id !== null && \in_array($method, [Request::REQUEST_TYPE_PATCH, Request::REQUEST_TYPE_PUT], true) === true) {
             return $this->call($this->methodNames['update']);
         }
 
         // Edit
-        if ($method === static::REQUEST_TYPE_GET && $id !== null && $action === 'edit') {
+        if ($method === Request::REQUEST_TYPE_GET && $id !== null && $action === 'edit') {
             return $this->call($this->methodNames['edit']);
         }
 
         // Create
-        if ($method === static::REQUEST_TYPE_GET && $id === 'create') {
+        if ($method === Request::REQUEST_TYPE_GET && $id === 'create') {
             return $this->call($this->methodNames['create']);
         }
 
         // Save
-        if ($method === static::REQUEST_TYPE_POST) {
+        if ($method === Request::REQUEST_TYPE_POST) {
             return $this->call($this->methodNames['store']);
         }
 
         // Show
-        if ($method === static::REQUEST_TYPE_GET && $id !== null) {
+        if ($method === Request::REQUEST_TYPE_GET && $id !== null) {
             return $this->call($this->methodNames['show']);
         }
 

--- a/src/Pecee/SimpleRouter/SimpleRouter.php
+++ b/src/Pecee/SimpleRouter/SimpleRouter.php
@@ -184,7 +184,7 @@ class SimpleRouter
      */
     public static function get(string $url, $callback, array $settings = null): IRoute
     {
-        return static::match(['get'], $url, $callback, $settings);
+        return static::match([Request::REQUEST_TYPE_GET], $url, $callback, $settings);
     }
 
     /**
@@ -197,7 +197,7 @@ class SimpleRouter
      */
     public static function post(string $url, $callback, array $settings = null): IRoute
     {
-        return static::match(['post'], $url, $callback, $settings);
+        return static::match([Request::REQUEST_TYPE_POST], $url, $callback, $settings);
     }
 
     /**
@@ -210,7 +210,7 @@ class SimpleRouter
      */
     public static function put(string $url, $callback, array $settings = null): IRoute
     {
-        return static::match(['put'], $url, $callback, $settings);
+        return static::match([Request::REQUEST_TYPE_PUT], $url, $callback, $settings);
     }
 
     /**
@@ -223,7 +223,7 @@ class SimpleRouter
      */
     public static function patch(string $url, $callback, array $settings = null): IRoute
     {
-        return static::match(['patch'], $url, $callback, $settings);
+        return static::match([Request::REQUEST_TYPE_PATCH], $url, $callback, $settings);
     }
 
     /**
@@ -236,7 +236,7 @@ class SimpleRouter
      */
     public static function options(string $url, $callback, array $settings = null): IRoute
     {
-        return static::match(['options'], $url, $callback, $settings);
+        return static::match([Request::REQUEST_TYPE_OPTIONS], $url, $callback, $settings);
     }
 
     /**
@@ -249,7 +249,7 @@ class SimpleRouter
      */
     public static function delete(string $url, $callback, array $settings = null): IRoute
     {
-        return static::match(['delete'], $url, $callback, $settings);
+        return static::match([Request::REQUEST_TYPE_DELETE], $url, $callback, $settings);
     }
 
     /**
@@ -313,7 +313,7 @@ class SimpleRouter
      */
     public static function basic(string $url, $callback, array $settings = null): IRoute
     {
-        return static::match(['get', 'post'], $url, $callback, $settings);
+        return static::form($url, $callback, $settings);
     }
 
     /**
@@ -328,7 +328,10 @@ class SimpleRouter
      */
     public static function form(string $url, $callback, array $settings = null): IRoute
     {
-        return static::match(['get', 'post'], $url, $callback, $settings);
+        return static::match([
+            Request::REQUEST_TYPE_GET,
+            Request::REQUEST_TYPE_POST
+        ], $url, $callback, $settings);
     }
 
     /**


### PR DESCRIPTION
- Moved request-types constants from abstract `Route` class to global `Request`-class and changed references.
- Changed code to use new global request-type constants.
- Optimized `InputHandler` class so it only parses inputs once when calling `all`-method.
- Forced `csrf-token` post-value are now available in all requestTypePost methods.