### PR TITLE
Add support for object without JsonSerializable

### DIFF
--- a/src/Pecee/Http/Response.php
+++ b/src/Pecee/Http/Response.php
@@ -92,8 +92,23 @@ class Response
      */
     public function json($value, ?int $options = null, int $dept = 512): void
     {
-        if (($value instanceof \JsonSerializable) === false && \is_array($value) === false) {
-            throw new InvalidArgumentException('Invalid type for parameter "value". Must be of type array or object implementing the \JsonSerializable interface.');
+        if(is_object($value)){
+            if(!$value instanceof \JsonSerializable){
+                $object_vars = array();
+                $class = new \ReflectionClass($value);
+                foreach($class->getProperties() as $property){
+                    if($property->isStatic())
+                        continue;
+                    $property->setAccessible(true);
+                    $object_vars[$property->getName()] = $property->getValue($value);
+                }
+                $value = $object_vars;
+                if(empty($object_vars)){
+                    throw new InvalidArgumentException('Invalid type for parameter "value". Must be of type array or object implementing the \JsonSerializable interface or object with variables.');
+                }
+            }
+        }else if(is_array($value) === false){
+            throw new InvalidArgumentException('Invalid type for parameter "value". Must be of type array or object implementing the \JsonSerializable interface or object with variables.');
         }
 
         $this->header('Content-Type: application/json; charset=utf-8');


### PR DESCRIPTION
Hello,

I think it would be great when we add support for returning an object without the `JsonSerializable`.
The function `get_object_vars()` only returns the public variables of an object ([when it is used out of the class itself](https://www.php.net/manual/de/function.get-object-vars.php#function.usort.examples.closure)). But when we create an ReflectionClass and then get the Properties, check if they are non static and add them, this would be a great alternative.
The only thing I'm not sure about is wheather to add private, protected and public variables to the return or to just return the private or the public.

~ Marius