### PR TITLE
[BUGFIX] BootManager findRoute not working.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1495,7 +1495,7 @@ class CustomRouterRules implement IRouterBootManager
 
             // If the current url matches the rewrite url, we use our custom route
 
-            if($request->getUrl()->getPath() === $url) {
+            if($request->getUrl()->contains($url)) {
                 $request->setRewriteUrl($rule);
             }
         }

--- a/src/Pecee/SimpleRouter/Router.php
+++ b/src/Pecee/SimpleRouter/Router.php
@@ -269,6 +269,13 @@ class Router
     {
         $this->debug('Loading routes');
 
+        $this->fireEvents(EventHandler::EVENT_LOAD_ROUTES, [
+            'routes' => $this->routes,
+        ]);
+
+        /* Loop through each route-request */
+        $this->processRoutes($this->routes);
+
         $this->fireEvents(EventHandler::EVENT_BOOT, [
             'bootmanagers' => $this->bootManagers,
         ]);
@@ -290,13 +297,6 @@ class Router
 
             $this->debug('Finished rendering bootmanager "%s"', $className);
         }
-
-        $this->fireEvents(EventHandler::EVENT_LOAD_ROUTES, [
-            'routes' => $this->routes,
-        ]);
-
-        /* Loop through each route-request */
-        $this->processRoutes($this->routes);
 
         $this->debug('Finished loading routes');
     }

--- a/tests/Pecee/SimpleRouter/BootManagerTest.php
+++ b/tests/Pecee/SimpleRouter/BootManagerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+require_once 'Dummy/DummyMiddleware.php';
+require_once 'Dummy/DummyController.php';
+require_once 'Dummy/Handler/ExceptionHandler.php';
+require_once 'Dummy/Managers/TestBootManager.php';
+require_once 'Dummy/Managers/FindUrlBootManager.php';
+
+class BootManagerTest extends \PHPUnit\Framework\TestCase
+{
+
+    public function testBootManagerRoutes()
+    {
+        $result = false;
+
+        TestRouter::get('/', function () use (&$result) {
+            $result = true;
+        });
+        TestRouter::get('/about', 'DummyController@method2');
+        TestRouter::get('/contact', 'DummyController@method3');
+
+        // Add boot-manager
+        TestRouter::addBootManager(new TestBootManager([
+            '/con'     => '/about',
+            '/contact' => '/',
+        ]));
+
+        TestRouter::debug('/contact');
+
+        $this->assertTrue($result);
+    }
+
+    public function testFindUrlFromBootManager()
+    {
+        TestRouter::get('/', 'DummyController@method1');
+        TestRouter::get('/about', 'DummyController@method2')->name('about');
+        TestRouter::get('/contact', 'DummyController@method3')->name('contact');
+
+        $result = false;
+
+        // Add boot-manager
+        TestRouter::addBootManager(new FindUrlBootManager($result));
+
+        TestRouter::debug('/');
+
+        $this->assertTrue($result);
+    }
+
+}

--- a/tests/Pecee/SimpleRouter/Dummy/Managers/FindUrlBootManager.php
+++ b/tests/Pecee/SimpleRouter/Dummy/Managers/FindUrlBootManager.php
@@ -1,0 +1,26 @@
+<?php
+
+class FindUrlBootManager implements \Pecee\SimpleRouter\IRouterBootManager
+{
+    protected $result;
+
+    public function __construct(&$result)
+    {
+        $this->result = &$result;
+    }
+
+    /**
+     * Called when router loads it's routes
+     *
+     * @param \Pecee\SimpleRouter\Router $router
+     * @param \Pecee\Http\Request $request
+     */
+    public function boot(\Pecee\SimpleRouter\Router $router, \Pecee\Http\Request $request): void
+    {
+        $contact = $router->findRoute('contact');
+
+        if($contact !== null) {
+            $this->result = true;
+        }
+    }
+}

--- a/tests/Pecee/SimpleRouter/Dummy/Managers/TestBootManager.php
+++ b/tests/Pecee/SimpleRouter/Dummy/Managers/TestBootManager.php
@@ -3,13 +3,11 @@
 class TestBootManager implements \Pecee\SimpleRouter\IRouterBootManager
 {
 
-    protected $routes;
-    protected $aliasUrl;
+    protected $rewrite;
 
-    public function __construct(array $routes, string $aliasUrl)
+    public function __construct(array $rewrite)
     {
-        $this->routes = $routes;
-        $this->aliasUrl = $aliasUrl;
+        $this->rewrite = $rewrite;
     }
 
     /**
@@ -20,11 +18,11 @@ class TestBootManager implements \Pecee\SimpleRouter\IRouterBootManager
      */
     public function boot(\Pecee\SimpleRouter\Router $router, \Pecee\Http\Request $request): void
     {
-        foreach ($this->routes as $url) {
+        foreach ($this->rewrite as $url => $rewrite) {
             // If the current url matches the rewrite url, we use our custom route
 
             if ($request->getUrl()->contains($url) === true) {
-                $request->setRewriteUrl($this->aliasUrl);
+                $request->setRewriteUrl($rewrite);
             }
 
         }

--- a/tests/Pecee/SimpleRouter/EventHandlerTest.php
+++ b/tests/Pecee/SimpleRouter/EventHandlerTest.php
@@ -50,8 +50,8 @@ class EventHandlerTest extends \PHPUnit\Framework\TestCase
 
         // Add boot-manager
         TestRouter::addBootManager(new TestBootManager([
-            '/test',
-        ], '/'));
+            '/test' => '/',
+        ]));
 
         // Start router
         TestRouter::debug('/non-existing');
@@ -61,7 +61,6 @@ class EventHandlerTest extends \PHPUnit\Framework\TestCase
 
     public function testAllEvent()
     {
-
         $status = false;
 
         $eventHandler = new EventHandler();


### PR DESCRIPTION
- Fixed `findRoute` not working in `BootManager` as reported by issue: #448
- Added more comprehensive php-unit tests for bootmanagers including `findUrl`.
- Updated documentation.