### PR TITLE
[IMPORTANT] PHPUnit fix: Element 'coverage': This element is not expected.

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,10 +15,10 @@
             <directory>tests/Pecee/SimpleRouter/</directory>
         </testsuite>
     </testsuites>
-    <coverage processUncoveredFiles="true"
-              ignoreDeprecatedCodeUnits="true">
-        <include>
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true"
+                   processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">src</directory>
-        </include>
-    </coverage>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
Hey,

`Element 'coverage': This element is not expected.`

This warning only shows up in some tests. I will try to fix it in this pull request.

~ Marius