### PR TITLE
Add response methods for api routes

### DIFF
--- a/src/Pecee/Http/Exceptions/JsonException.php
+++ b/src/Pecee/Http/Exceptions/JsonException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Pecee\Http\Exceptions;
+
+/**
+ * <p>Class JsonException</p>
+ * <b>Used to Support php 7.1 until this exception is added in php 7.3</b>
+ * @package Pecee\Http\Exceptions
+ */
+class JsonException extends \Exception{
+
+}

--- a/src/Pecee/Http/Response.php
+++ b/src/Pecee/Http/Response.php
@@ -123,25 +123,24 @@ class Response
 
     /**
      * Json encode and print successful response.
-     * @param array|JsonSerializable $value
+     * @param array|JsonSerializable $data
      * @param int $code - response code
      * @param ?int $options JSON options Bitmask consisting of JSON_HEX_QUOT, JSON_HEX_TAG, JSON_HEX_AMP, JSON_HEX_APOS, JSON_NUMERIC_CHECK, JSON_PRETTY_PRINT, JSON_UNESCAPED_SLASHES, JSON_FORCE_OBJECT, JSON_PRESERVE_ZERO_FRACTION, JSON_UNESCAPED_UNICODE, JSON_PARTIAL_OUTPUT_ON_ERROR.
      * @param int $dept JSON debt.
      * @throws InvalidArgumentException
      * @throws JsonException
      */
-    public function success($value, $code = 200, ?int $options = null, int $dept = 512): void
+    public function apiSuccess($data = array(), $code = 200, ?int $options = null, int $dept = 512): void
     {
         $this->setUpJsonResponse(array(
             'success' => true,
             'code' => $code,
-            'data' => $value
-        ), $value, $options, $dept);
+            'data' => $data
+        ), $data, $options, $dept);
     }
 
     /**
      * Json encode and print error response.
-     * @param array|JsonSerializable $value
      * @param string $message - error message
      * @param int $code - response code
      * @param array $errors - a list of errors
@@ -149,15 +148,14 @@ class Response
      * @param int $dept JSON debt.
      * @throws JsonException
      */
-    public function error($value, string $message, $code = 400, array $errors = array(), ?int $options = null, int $dept = 512): void
+    public function apiError(string $message, $code = 400, array $errors = array(), ?int $options = null, int $dept = 512): void
     {
         $this->setUpJsonResponse(array(
             'success' => false,
             'message' => $message,
             'code' => $code,
-            'errors' => $errors,
-            'data' => $value
-        ), $value, $options, $dept);
+            'errors' => $errors
+        ), array(), $options, $dept);
     }
 
     /**


### PR DESCRIPTION
Hey,

I know not everyone handles/ prints an api response like this, but when I speak for myself I would love to use these methods, because it really minifys my code and kind of forces/ gives me the oppotunity to return `errors` and response `codes` to my frontend.
I currently have to write "a lot" of code to setup the structure for my json error and success response. This could help a lot!

I also added a small check if the json is encoded properly.

What do you think?

~ Marius