### PR TITLE
[BUGFIX] Fixed group not matching domain with no parameters (issue: #468)

### DIFF
--- a/src/Pecee/SimpleRouter/Route/RouteGroup.php
+++ b/src/Pecee/SimpleRouter/Route/RouteGroup.php
@@ -26,12 +26,15 @@ class RouteGroup extends Route implements IGroupRoute
 
         foreach ($this->domains as $domain) {
 
+            // If domain has no parameters but matches
+            if ($domain === $request->getHost()) {
+                return true;
+            }
+
             $parameters = $this->parseParameters($domain, $request->getHost(), '.*');
 
             if ($parameters !== null && \count($parameters) !== 0) {
-
                 $this->parameters = $parameters;
-
                 return true;
             }
         }
@@ -56,7 +59,7 @@ class RouteGroup extends Route implements IGroupRoute
 
         $prefix = $this->prefix;
 
-        foreach($this->getParameters() as $parameter => $value) {
+        foreach ($this->getParameters() as $parameter => $value) {
             $prefix = str_ireplace('{' . $parameter . '}', $value, $prefix);
         }
 

--- a/tests/Pecee/SimpleRouter/RouterRouteTest.php
+++ b/tests/Pecee/SimpleRouter/RouterRouteTest.php
@@ -107,6 +107,42 @@ class RouterRouteTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('it, system', $response);
     }
 
+    public function testFixedDomain()
+    {
+        $result = false;
+        TestRouter::request()->setHost('admin.world.com');
+
+        TestRouter::group(['domain' => 'admin.world.com'], function () use (&$result) {
+            TestRouter::get('/test', function ($subdomain = null) use (&$result) {
+                $result = true;
+            });
+        });
+
+        TestRouter::debug('/test', 'get');
+
+        $this->assertTrue($result);
+    }
+
+    public function testFixedNotAllowedDomain()
+    {
+        $result = false;
+        TestRouter::request()->setHost('other.world.com');
+
+        TestRouter::group(['domain' => 'admin.world.com'], function () use (&$result) {
+            TestRouter::get('/', function ($subdomain = null) use (&$result) {
+                $result = true;
+            });
+        });
+
+        try {
+            TestRouter::debug('/', 'get');
+        } catch(\Exception $e) {
+
+        }
+
+        $this->assertFalse($result);
+    }
+
     public function testDomainAllowedRoute()
     {
         $result = false;


### PR DESCRIPTION
- Tests: Added tests for groups with domain with no parameters.