### PR TITLE
Bugfixes

### DIFF
--- a/src/Pecee/Http/Input/InputFile.php
+++ b/src/Pecee/Http/Input/InputFile.php
@@ -216,11 +216,11 @@ class InputFile implements IInputItem
     /**
      * Get upload-error code.
      *
-     * @return int
+     * @return int|null
      */
-    public function getError(): int
+    public function getError(): ?int
     {
-        return (int)$this->errors;
+        return $this->errors;
     }
 
     /**

--- a/src/Pecee/Http/Url.php
+++ b/src/Pecee/Http/Url.php
@@ -248,8 +248,9 @@ class Url implements JsonSerializable
     public function setQueryString(string $queryString): self
     {
         $params = [];
+        parse_str($queryString, $params);
 
-        if(parse_str($queryString, $params) !== false) {
+        if(count($params) > 0) {
             return $this->setParams($params);
         }
 
@@ -341,7 +342,7 @@ class Url implements JsonSerializable
      */
     public function removeParams(...$names): self
     {
-        $params = array_diff_key($this->getParams(), array_flip($names));
+        $params = array_diff_key($this->getParams(), array_flip(...$names));
         $this->setParams($params);
 
         return $this;

--- a/src/Pecee/SimpleRouter/Route/Route.php
+++ b/src/Pecee/SimpleRouter/Route/Route.php
@@ -337,6 +337,17 @@ abstract class Route implements IRoute
      */
     public function setNamespace(string $namespace): IRoute
     {
+        $ns = $this->getNamespace();
+
+        if ($ns !== null) {
+            // Don't overwrite namespaces that starts with \
+            if ($ns[0] !== '\\') {
+                $namespace .= '\\' . $ns;
+            } else {
+                $namespace = $ns;
+            }
+        }
+
         $this->namespace = $namespace;
 
         return $this;
@@ -407,7 +418,7 @@ abstract class Route implements IRoute
      */
     public function setSettings(array $settings, bool $merge = false): IRoute
     {
-        if ($this->namespace === null && isset($settings['namespace']) === true) {
+        if (isset($settings['namespace']) === true) {
             $this->setNamespace($settings['namespace']);
         }
 

--- a/src/Pecee/SimpleRouter/Router.php
+++ b/src/Pecee/SimpleRouter/Router.php
@@ -509,7 +509,7 @@ class Router
         ]);
 
         /* @var $handler IExceptionHandler */
-        foreach ($this->exceptionHandlers as $key => $handler) {
+        foreach (array_reverse($this->exceptionHandlers) as $key => $handler) {
 
             if (is_object($handler) === false) {
                 $handler = new $handler();

--- a/src/Pecee/SimpleRouter/SimpleRouter.php
+++ b/src/Pecee/SimpleRouter/SimpleRouter.php
@@ -348,7 +348,7 @@ class SimpleRouter
      * @param array|null $settings
      * @return RouteUrl|IRoute
      */
-    public static function match(array $requestMethods, string $url, $callback, array $settings = null)
+    public static function match(array $requestMethods, string $url, $callback, array $settings = null): IRoute
     {
         $route = new RouteUrl($url, $callback);
         $route->setRequestMethods($requestMethods);
@@ -368,7 +368,7 @@ class SimpleRouter
      * @param array|null $settings
      * @return RouteUrl|IRoute
      */
-    public static function all(string $url, $callback, array $settings = null)
+    public static function all(string $url, $callback, array $settings = null): IRoute
     {
         $route = new RouteUrl($url, $callback);
 
@@ -387,7 +387,7 @@ class SimpleRouter
      * @param array|null $settings
      * @return RouteController|IRoute
      */
-    public static function controller(string $url, string $controller, array $settings = null)
+    public static function controller(string $url, string $controller, array $settings = null): IRoute
     {
         $route = new RouteController($url, $controller);
 
@@ -406,7 +406,7 @@ class SimpleRouter
      * @param array|null $settings
      * @return RouteResource|IRoute
      */
-    public static function resource(string $url, string $controller, array $settings = null)
+    public static function resource(string $url, string $controller, array $settings = null): IRoute
     {
         $route = new RouteResource($url, $controller);
 
@@ -512,20 +512,7 @@ class SimpleRouter
     public static function addDefaultNamespace(IRoute $route): IRoute
     {
         if (static::$defaultNamespace !== null) {
-
-            $ns = static::$defaultNamespace;
-            $namespace = $route->getNamespace();
-
-            if ($namespace !== null) {
-                // Don't overwrite namespaces that starts with \
-                if ($namespace[0] !== '\\') {
-                    $ns .= '\\' . $namespace;
-                } else {
-                    $ns = $namespace;
-                }
-            }
-
-            $route->setNamespace($ns);
+            $route->setNamespace(static::$defaultNamespace);
         }
 
         return $route;

--- a/tests/Pecee/SimpleRouter/RouterGroupTest.php
+++ b/tests/Pecee/SimpleRouter/RouterGroupTest.php
@@ -3,20 +3,20 @@
 require_once 'Dummy/DummyMiddleware.php';
 require_once 'Dummy/DummyController.php';
 
-class GroupTest extends \PHPUnit\Framework\TestCase
+class RouterGroupTest extends \PHPUnit\Framework\TestCase
 {
 
     public function testGroupLoad()
     {
         $result = false;
 
-        TestRouter::group(['prefix' => '/group'], function () use(&$result) {
+        TestRouter::group(['prefix' => '/group'], function () use (&$result) {
             $result = true;
         });
 
         try {
             TestRouter::debug('/', 'get');
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
 
         }
         $this->assertTrue($result);
@@ -79,6 +79,42 @@ class GroupTest extends \PHPUnit\Framework\TestCase
 
         TestRouter::router()->reset();
 
+    }
+
+    public function testNamespaceExtend()
+    {
+        TestRouter::group(['namespace' => '\My\Namespace'], function () use (&$result) {
+
+            TestRouter::group(['namespace' => 'Service'], function () use (&$result) {
+
+                TestRouter::get('/test', function () use (&$result) {
+                    return \Pecee\SimpleRouter\SimpleRouter::router()->getRequest()->getLoadedRoute()->getNamespace();
+                });
+
+            });
+
+        });
+
+        $namespace = TestRouter::debugOutput('/test');
+        $this->assertEquals('\My\Namespace\Service', $namespace);
+    }
+
+    public function testNamespaceOverwrite()
+    {
+        TestRouter::group(['namespace' => '\My\Namespace'], function () use (&$result) {
+
+            TestRouter::group(['namespace' => '\Service'], function () use (&$result) {
+
+                TestRouter::get('/test', function () use (&$result) {
+                    return \Pecee\SimpleRouter\SimpleRouter::router()->getRequest()->getLoadedRoute()->getNamespace();
+                });
+
+            });
+
+        });
+
+        $namespace = TestRouter::debugOutput('/test');
+        $this->assertEquals('\Service', $namespace);
     }
 
 }

--- a/tests/Pecee/SimpleRouter/RouterRewriteTest.php
+++ b/tests/Pecee/SimpleRouter/RouterRewriteTest.php
@@ -49,9 +49,9 @@ class RouterRewriteTest extends \PHPUnit\Framework\TestCase
         }
 
         $expectedStack = [
-            ExceptionHandlerFirst::class,
-            ExceptionHandlerSecond::class,
             ExceptionHandlerThird::class,
+            ExceptionHandlerSecond::class,
+            ExceptionHandlerFirst::class,
         ];
 
         $this->assertEquals($expectedStack, $stack);


### PR DESCRIPTION
- [FEATURE] Namespace overwrite now works globally. `Service` will append to any existing namespace whereas `\Service` will overwrite it.
- [FEATURE] Exception handlers are now rendered in reverse order from newest to oldest. This allows for exceptions to be handled from parent exceptions which were otherwise ignored.
- Fixed incorrect return type for `InputFile::getError` to correct nullable int.
- Added return type to `all`, `match`, `controller` and `resource` in `SimpleRouter` class.
- Fixed incorrect return-type usage of `parse_str` function in `Url::setQueryString` method.
- Fixed incorrect expected value in `array_flip` function in `Url::removeParams` method.
- Tests: added namespace overwrite group unit-tests.