### PR TITLE
InputHandler optimisations.

### DIFF
--- a/src/Pecee/Http/Input/InputHandler.php
+++ b/src/Pecee/Http/Input/InputHandler.php
@@ -308,10 +308,10 @@ class InputHandler
      * Find post-value by index or return default value.
      *
      * @param string $index
-     * @param string|null $defaultValue
+     * @param mixed|null $defaultValue
      * @return InputItem|array|string|null
      */
-    public function post(string $index, ?string $defaultValue = null)
+    public function post(string $index, $defaultValue = null)
     {
         return $this->post[$index] ?? $defaultValue;
     }
@@ -320,10 +320,10 @@ class InputHandler
      * Find file by index or return default value.
      *
      * @param string $index
-     * @param string|null $defaultValue
+     * @param mixed|null $defaultValue
      * @return InputFile|array|string|null
      */
-    public function file(string $index, ?string $defaultValue = null)
+    public function file(string $index, $defaultValue = null)
     {
         return $this->file[$index] ?? $defaultValue;
     }
@@ -332,10 +332,10 @@ class InputHandler
      * Find parameter/query-string by index or return default value.
      *
      * @param string $index
-     * @param string|null $defaultValue
+     * @param mixed|null $defaultValue
      * @return InputItem|array|string|null
      */
-    public function get(string $index, ?string $defaultValue = null)
+    public function get(string $index, $defaultValue = null)
     {
         return $this->get[$index] ?? $defaultValue;
     }

--- a/src/Pecee/Http/Input/InputItem.php
+++ b/src/Pecee/Http/Input/InputItem.php
@@ -2,10 +2,11 @@
 
 namespace Pecee\Http\Input;
 
+use ArrayAccess;
 use ArrayIterator;
 use IteratorAggregate;
 
-class InputItem implements IInputItem, IteratorAggregate
+class InputItem implements ArrayAccess, IInputItem, IteratorAggregate
 {
     public $index;
     public $name;
@@ -75,9 +76,34 @@ class InputItem implements IInputItem, IteratorAggregate
         return $this;
     }
 
+    public function offsetExists($offset): bool
+    {
+        return isset($this->value[$offset]);
+    }
+
+    public function offsetGet($offset)
+    {
+        if ($this->offsetExists($offset) === true) {
+            return $this->value[$offset];
+        }
+
+        return null;
+    }
+
+    public function offsetSet($offset, $value): void
+    {
+        $this->value[$offset] = $value;
+    }
+
+    public function offsetUnset($offset): void
+    {
+        unset($this->data[$offset]);
+    }
+
     public function __toString(): string
     {
         $value = $this->getValue();
+
         return (is_array($value) === true) ? json_encode($value) : $value;
     }
 

--- a/tests/Pecee/SimpleRouter/Dummy/ClassLoader/CustomClassLoader.php
+++ b/tests/Pecee/SimpleRouter/Dummy/ClassLoader/CustomClassLoader.php
@@ -16,11 +16,11 @@ class CustomClassLoader implements \Pecee\SimpleRouter\ClassLoader\IClassLoader
      */
     public function loadClassMethod($class, string $method, array $parameters)
     {
-        return call_user_func_array([$class, $method], ['result' => true]);
+        return call_user_func_array([$class, $method], [true]);
     }
 
     public function loadClosure(callable $closure, array $parameters)
     {
-        return call_user_func_array($closure, ['result' => true]);
+        return call_user_func_array($closure, [true]);
     }
 }


### PR DESCRIPTION
- `InputItem` can now be used like array (for example: `input()->post('items')[0]`) if value is array.
- Changed default-value parameter for `get`, `post` and `file` methods to allow for mixed object as return-type `(input()->post('form', new InputItem('post'))`.
- Fixed `InputItem->__toString()` to correctly parse `null` default-value.
- Tests: changed parameter in `call_user_func_array` for PHP 8 compatibility in unit-tests.