### PR TITLE
SimpleRouter::error not working within group

### DIFF
--- a/src/Pecee/SimpleRouter/SimpleRouter.php
+++ b/src/Pecee/SimpleRouter/SimpleRouter.php
@@ -432,9 +432,7 @@ class SimpleRouter
         $group = new RouteGroup();
         $group->addExceptionHandler($callbackHandler);
 
-        array_unshift($routes, $group);
-
-        static::router()->setRoutes($routes);
+        static::router()->addRoute($group);
 
         return $callbackHandler;
     }

--- a/src/Pecee/SimpleRouter/SimpleRouter.php
+++ b/src/Pecee/SimpleRouter/SimpleRouter.php
@@ -425,14 +425,11 @@ class SimpleRouter
      */
     public static function error(Closure $callback): CallbackExceptionHandler
     {
-        $routes = static::router()->getRoutes();
-
         $callbackHandler = new CallbackExceptionHandler($callback);
 
-        $group = new RouteGroup();
-        $group->addExceptionHandler($callbackHandler);
-
-        static::router()->addRoute($group);
+        static::router()->addRoute(
+            (new RouteGroup())->addExceptionHandler($callbackHandler)
+        );
 
         return $callbackHandler;
     }

--- a/tests/Pecee/SimpleRouter/RouterCallbackExceptionHandlerTest.php
+++ b/tests/Pecee/SimpleRouter/RouterCallbackExceptionHandlerTest.php
@@ -19,10 +19,29 @@ class RouterCallbackExceptionHandlerTest extends \PHPUnit\Framework\TestCase
             throw new ExceptionHandlerException();
         });
 
-        TestRouter::debugNoReset('/404-url', 'get');
-        TestRouter::router()->reset();
+        TestRouter::debug('/404-url');
+    }
 
-        $this->assertTrue(true);
+    public function testExceptionHandlerCallback() {
+
+        TestRouter::group(['prefix' => null], function() {
+            TestRouter::get('/', function() {
+                return 'Hello world';
+            });
+
+            TestRouter::get('/not-found', 'DummyController@method1');
+            TestRouter::error(function(\Pecee\Http\Request $request, \Exception $exception) {
+
+                if($exception instanceof \Pecee\SimpleRouter\Exceptions\NotFoundHttpException && $exception->getCode() === 404) {
+                    return $request->setRewriteCallback(static function() {
+                        return 'success';
+                    });
+                }
+            });
+        });
+
+        $result = TestRouter::debugOutput('/thisdoes-not/existssss', 'get');
+        $this->assertEquals('success', $result);
     }
 
 }


### PR DESCRIPTION
- Issue #551 Fixed issue causing `SimpleRouter::error` helper not to work when used within a group.
- Tests: added unit test for nested group calls to `SimpleRouter::error`.