### PR TITLE
Version 4.3.4.2

### DIFF
--- a/src/Pecee/Http/Input/InputItem.php
+++ b/src/Pecee/Http/Input/InputItem.php
@@ -97,7 +97,7 @@ class InputItem implements ArrayAccess, IInputItem, IteratorAggregate
 
     public function offsetUnset($offset): void
     {
-        unset($this->data[$offset]);
+        unset($this->value[$offset]);
     }
 
     public function __toString(): string

--- a/src/Pecee/Http/Request.php
+++ b/src/Pecee/Http/Request.php
@@ -264,12 +264,12 @@ class Request
      * Get header value by name
      *
      * @param string $name Name of the header.
-     * @param string|null $defaultValue Value to be returned if header is not found.
+     * @param string|mixed|null $defaultValue Value to be returned if header is not found.
      * @param bool $tryParse When enabled the method will try to find the header from both from client (http) and server-side variants, if the header is not found.
      *
      * @return string|null
      */
-    public function getHeader(string $name, $defaultValue = null, $tryParse = true): ?string
+    public function getHeader(string $name, $defaultValue = null, bool $tryParse = true): ?string
     {
         $name = strtolower($name);
         $header = $this->headers[$name] ?? null;

--- a/src/Pecee/Http/Url.php
+++ b/src/Pecee/Http/Url.php
@@ -431,7 +431,7 @@ class Url implements JsonSerializable
      * @param bool $includeParams
      * @return string
      */
-    public function getRelativeUrl($includeParams = true): string
+    public function getRelativeUrl(bool $includeParams = true): string
     {
         $path = $this->path ?? '/';
 
@@ -451,7 +451,7 @@ class Url implements JsonSerializable
      * @param bool $includeParams
      * @return string
      */
-    public function getAbsoluteUrl($includeParams = true): string
+    public function getAbsoluteUrl(bool $includeParams = true): string
     {
         $scheme = $this->scheme !== null ? $this->scheme . '://' : '';
         $host = $this->host ?? '';

--- a/src/Pecee/SimpleRouter/Router.php
+++ b/src/Pecee/SimpleRouter/Router.php
@@ -944,4 +944,10 @@ class Router
         return $this;
     }
 
+    public function addExceptionHandler(IExceptionHandler $handler): self
+    {
+        $this->exceptionHandlers[] = $handler;
+        return $this;
+    }
+
 }

--- a/src/Pecee/SimpleRouter/SimpleRouter.php
+++ b/src/Pecee/SimpleRouter/SimpleRouter.php
@@ -425,16 +425,11 @@ class SimpleRouter
      */
     public static function error(Closure $callback): CallbackExceptionHandler
     {
-        $routes = static::router()->getRoutes();
-
         $callbackHandler = new CallbackExceptionHandler($callback);
 
-        $group = new RouteGroup();
-        $group->addExceptionHandler($callbackHandler);
-
-        array_unshift($routes, $group);
-
-        static::router()->setRoutes($routes);
+        static::router()->addRoute(
+            (new RouteGroup())->addExceptionHandler($callbackHandler)
+        );
 
         return $callbackHandler;
     }

--- a/src/Pecee/SimpleRouter/SimpleRouter.php
+++ b/src/Pecee/SimpleRouter/SimpleRouter.php
@@ -427,9 +427,7 @@ class SimpleRouter
     {
         $callbackHandler = new CallbackExceptionHandler($callback);
 
-        static::router()->addRoute(
-            (new RouteGroup())->addExceptionHandler($callbackHandler)
-        );
+        static::router()->addExceptionHandler($callbackHandler);
 
         return $callbackHandler;
     }

--- a/tests/Pecee/SimpleRouter/RouterCallbackExceptionHandlerTest.php
+++ b/tests/Pecee/SimpleRouter/RouterCallbackExceptionHandlerTest.php
@@ -19,10 +19,29 @@ class RouterCallbackExceptionHandlerTest extends \PHPUnit\Framework\TestCase
             throw new ExceptionHandlerException();
         });
 
-        TestRouter::debugNoReset('/404-url', 'get');
-        TestRouter::router()->reset();
+        TestRouter::debug('/404-url');
+    }
 
-        $this->assertTrue(true);
+    public function testExceptionHandlerCallback() {
+
+        TestRouter::group(['prefix' => null], function() {
+            TestRouter::get('/', function() {
+                return 'Hello world';
+            });
+
+            TestRouter::get('/not-found', 'DummyController@method1');
+            TestRouter::error(function(\Pecee\Http\Request $request, \Exception $exception) {
+
+                if($exception instanceof \Pecee\SimpleRouter\Exceptions\NotFoundHttpException && $exception->getCode() === 404) {
+                    return $request->setRewriteCallback(static function() {
+                        return 'success';
+                    });
+                }
+            });
+        });
+
+        $result = TestRouter::debugOutput('/thisdoes-not/existssss', 'get');
+        $this->assertEquals('success', $result);
     }
 
 }


### PR DESCRIPTION
- Issue #551: Fixed issue with SimpleRouter::error not firing within group.
- Fixed variable incorrect variable reference in `InputItem` class.
- Added new `Router::addExceptionHandler` method.
- Added parameter types in `Url` class.
- Fixed phpdoc parameter-type for `Request::getHeader`.