### PR TITLE
Fixed custom regex (setMatch) not setting parsed parameters (issue: #566)

### DIFF
--- a/src/Pecee/Http/Input/InputFile.php
+++ b/src/Pecee/Http/Input/InputFile.php
@@ -6,12 +6,39 @@ use Pecee\Exceptions\InvalidArgumentException;
 
 class InputFile implements IInputItem
 {
+    /**
+     * @var string
+     */
     public $index;
+
+    /**
+     * @var string
+     */
     public $name;
+
+    /**
+     * @var string|null
+     */
     public $filename;
+
+    /**
+     * @var int|null
+     */
     public $size;
+
+    /**
+     * @var int|null
+     */
     public $type;
+
+    /**
+     * @var int
+     */
     public $errors;
+
+    /**
+     * @var string|null
+     */
     public $tmpName;
 
     public function __construct(string $index)

--- a/src/Pecee/Http/Middleware/BaseCsrfVerifier.php
+++ b/src/Pecee/Http/Middleware/BaseCsrfVerifier.php
@@ -18,11 +18,16 @@ class BaseCsrfVerifier implements IMiddleware
      * @var array|null
      */
     protected $except;
+
     /**
      * Urls to include. Can be used to include urls from a certain path.
      * @var array|null
      */
     protected $include;
+
+    /**
+     * @var ITokenProvider
+     */
     protected $tokenProvider;
 
     /**

--- a/src/Pecee/Http/Security/CookieTokenProvider.php
+++ b/src/Pecee/Http/Security/CookieTokenProvider.php
@@ -9,7 +9,14 @@ class CookieTokenProvider implements ITokenProvider
 {
     public const CSRF_KEY = 'CSRF-TOKEN';
 
+    /**
+     * @var string
+     */
     protected $token;
+
+    /**
+     * @var int
+     */
     protected $cookieTimeoutMinutes = 120;
 
     /**

--- a/src/Pecee/Http/Url.php
+++ b/src/Pecee/Http/Url.php
@@ -7,15 +7,49 @@ use Pecee\Http\Exceptions\MalformedUrlException;
 
 class Url implements JsonSerializable
 {
+    /**
+     * @var string|null
+     */
     private $originalUrl;
 
+    /**
+     * @var string|null
+     */
     private $scheme;
+
+    /**
+     * @var string|null
+     */
     private $host;
+
+    /**
+     * @var int|null
+     */
     private $port;
+
+    /**
+     * @var string|null
+     */
     private $username;
+
+    /**
+     * @var string|null
+     */
     private $password;
+
+    /**
+     * @var string|null
+     */
     private $path;
+
+    /**
+     * @var array
+     */
     private $params = [];
+
+    /**
+     * @var string|null
+     */
     private $fragment;
 
     /**

--- a/src/Pecee/SimpleRouter/Event/EventArgument.php
+++ b/src/Pecee/SimpleRouter/Event/EventArgument.php
@@ -24,7 +24,7 @@ class EventArgument implements IEventArgument
      */
     protected $arguments = [];
 
-    public function __construct($eventName, $router, array $arguments = [])
+    public function __construct(string $eventName, Router $router, array $arguments = [])
     {
         $this->eventName = $eventName;
         $this->router = $router;
@@ -94,7 +94,7 @@ class EventArgument implements IEventArgument
      * @param mixed $value
      * @throws InvalidArgumentException
      */
-    public function __set(string $name, $value)
+    public function __set(string $name, $value): void
     {
         throw new InvalidArgumentException('Not supported');
     }

--- a/src/Pecee/SimpleRouter/Exceptions/ClassNotFoundHttpException.php
+++ b/src/Pecee/SimpleRouter/Exceptions/ClassNotFoundHttpException.php
@@ -6,10 +6,17 @@ use Throwable;
 
 class ClassNotFoundHttpException extends NotFoundHttpException
 {
+    /**
+     * @var string
+     */
     protected $class;
+
+    /**
+     * @var string|null
+     */
     protected $method;
 
-    public function __construct(string $class, ?string $method = null, $message = "", $code = 0, Throwable $previous = null)
+    public function __construct(string $class, ?string $method = null, string $message = "", int $code = 0, Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
 

--- a/src/Pecee/SimpleRouter/Handlers/CallbackExceptionHandler.php
+++ b/src/Pecee/SimpleRouter/Handlers/CallbackExceptionHandler.php
@@ -17,6 +17,9 @@ use Pecee\Http\Request;
 class CallbackExceptionHandler implements IExceptionHandler
 {
 
+    /**
+     * @var Closure
+     */
     protected $callback;
 
     public function __construct(Closure $callback)

--- a/src/Pecee/SimpleRouter/Handlers/DebugEventHandler.php
+++ b/src/Pecee/SimpleRouter/Handlers/DebugEventHandler.php
@@ -47,7 +47,7 @@ class DebugEventHandler implements IEventHandler
     public function fireEvents(Router $router, string $name, array $eventArgs = []): void
     {
         $callback = $this->callback;
-        $callback(new EventArgument($router, $eventArgs));
+        $callback(new EventArgument($name, $router, $eventArgs));
     }
 
     /**

--- a/src/Pecee/SimpleRouter/Route/LoadableRoute.php
+++ b/src/Pecee/SimpleRouter/Route/LoadableRoute.php
@@ -19,6 +19,9 @@ abstract class LoadableRoute extends Route implements ILoadableRoute
      */
     protected $name;
 
+    /**
+     * @var string|null
+     */
     protected $regex;
 
     /**
@@ -59,7 +62,14 @@ abstract class LoadableRoute extends Route implements ILoadableRoute
             return null;
         }
 
-        return ((bool)preg_match($this->regex, $url) !== false);
+        $parameters = [];
+        if ((bool)preg_match($this->regex, $url, $parameters) !== false) {
+            $this->setParameters($parameters);
+
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/src/Pecee/SimpleRouter/Route/RouteUrl.php
+++ b/src/Pecee/SimpleRouter/Route/RouteUrl.php
@@ -6,7 +6,12 @@ use Pecee\Http\Request;
 
 class RouteUrl extends LoadableRoute
 {
-    public function __construct($url, $callback)
+    /**
+     * RouteUrl constructor.
+     * @param string $url
+     * @param \Closure|string $callback
+     */
+    public function __construct(string $url, $callback)
     {
         $this->setUrl($url);
         $this->setCallback($callback);

--- a/tests/Pecee/SimpleRouter/RouterUrlTest.php
+++ b/tests/Pecee/SimpleRouter/RouterUrlTest.php
@@ -181,6 +181,22 @@ class RouterUrlTest extends \PHPUnit\Framework\TestCase
 
         $output = TestRouter::debugOutput('/admin/asd/bec/123', 'get');
         $this->assertEquals('match', $output);
+
+        TestRouter::router()->reset();
+    }
+
+    public function testCustomRegexWithParameter()
+    {
+        TestRouter::request()->setHost('google.com');
+
+        $results = '';
+
+        TestRouter::get('/tester/{param}', function ($param = null) use($results) {
+            return $results = $param;
+        })->setMatch('/(.*)/i');
+
+        $output = TestRouter::debugOutput('/tester/abepik/ko');
+        $this->assertEquals('/tester/abepik/ko/', $output);
     }
 
     public function testRenderMultipleRoutesDisabled()

--- a/tests/TestRouter.php
+++ b/tests/TestRouter.php
@@ -8,7 +8,7 @@ class TestRouter extends \Pecee\SimpleRouter\SimpleRouter
         static::request()->setHost('testhost.com');
     }
 
-    public static function debugNoReset($testUrl, $testMethod = 'get')
+    public static function debugNoReset(string $testUrl, string $testMethod = 'get'): void
     {
         $request = static::request();
 
@@ -18,7 +18,7 @@ class TestRouter extends \Pecee\SimpleRouter\SimpleRouter
         static::start();
     }
 
-    public static function debug($testUrl, $testMethod = 'get', bool $reset = true)
+    public static function debug(string $testUrl, string $testMethod = 'get', bool $reset = true): void
     {
         try {
             static::debugNoReset($testUrl, $testMethod);
@@ -35,7 +35,7 @@ class TestRouter extends \Pecee\SimpleRouter\SimpleRouter
 
     }
 
-    public static function debugOutput($testUrl, $testMethod = 'get', bool $reset = true)
+    public static function debugOutput(string $testUrl, string $testMethod = 'get', bool $reset = true): string
     {
         $response = null;
 


### PR DESCRIPTION
- Fixed DebugHandler::fireEvent not providing correct arguments when calling fireEvents.
- Fixed custom regex setMatch not setting parsed parameters correctly (issue: #566).
- Added unit-tests for catching issue in the future.
- Added php-stan typehints.