### PR TITLE
Added group attribute to stop router from merging exception-handlers (issue: #573)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ You can donate any amount of your choice by [clicking here](https://www.paypal.c
 - [ExceptionHandlers](#exceptionhandlers)
     - [Handling 404, 403 and other errors](#handling-404-403-and-other-errors)
 	- [Using custom exception handlers](#using-custom-exception-handlers)
+		- [Stop merge of parent exception-handlers](#stop-merge-of-parent-exception-handlers)
 - [Urls](#urls)
     - [Get the current url](#get-the-current-url)
  	- [Get by name (single route)](#get-by-name-single-route)
@@ -1013,6 +1014,41 @@ class CustomExceptionHandler implements IExceptionHandler
 
 }
 ```
+
+You can add your custom exception-handler class to your group by using the `exceptionHandler` settings-attribute.
+`exceptionHandler` can be either class-name or array of class-names.
+
+```php
+SimpleRouter::group(['exceptionHandler' => \Demo\Handlers\CustomExceptionHandler::class], function() {
+
+    // Your routes here
+
+});
+```
+
+### Stop merge of parent exception-handlers
+
+By default the router will merge exception-handlers to any handlers provided by parent groups, and will be executed in the order of newest to oldest.
+
+If you want your groups exception handler to be executed independently, you can add the `mergeExceptionHandlers` attribute and set it to `false`.
+
+```php
+SimpleRouter::group(['prefix' => '/', 'exceptionHandler' => \Demo\Handlers\FirstExceptionHandler::class, 'mergeExceptionHandlers' => false], function() {
+
+	SimpleRouter::group(['prefix' => '/admin', 'exceptionHandler' => \Demo\Handlers\SecondExceptionHandler::class], function() {
+	
+		// Both SecondExceptionHandler and FirstExceptionHandler will trigger (in that order).
+	
+	});
+	
+	SimpleRouter::group(['prefix' => '/user', 'exceptionHandler' => \Demo\Handlers\SecondExceptionHandler::class, 'mergeExceptionHandlers' => false], function() {
+	
+		// Only SecondExceptionHandler will trigger.
+	
+	});
+
+});
+``.
 
 ---
 

--- a/src/Pecee/SimpleRouter/Route/IGroupRoute.php
+++ b/src/Pecee/SimpleRouter/Route/IGroupRoute.php
@@ -32,6 +32,21 @@ interface IGroupRoute extends IRoute
     public function setExceptionHandlers(array $handlers): self;
 
     /**
+     * Returns true if group should overwrite existing exception-handlers.
+     *
+     * @return bool
+     */
+    public function getMergeExceptionHandlers(): bool;
+
+    /**
+     * When enabled group will overwrite any existing exception-handlers.
+     *
+     * @param bool $merge
+     * @return static
+     */
+    public function setMergeExceptionHandlers(bool $merge): self;
+
+    /**
      * Get exception-handlers for group
      *
      * @return array

--- a/src/Pecee/SimpleRouter/Route/RouteGroup.php
+++ b/src/Pecee/SimpleRouter/Route/RouteGroup.php
@@ -12,6 +12,7 @@ class RouteGroup extends Route implements IGroupRoute
     protected $name;
     protected $domains = [];
     protected $exceptionHandlers = [];
+    protected $mergeExceptionHandlers = true;
 
     /**
      * Method called to check if a domain matches
@@ -36,6 +37,7 @@ class RouteGroup extends Route implements IGroupRoute
 
             if ($parameters !== null && count($parameters) !== 0) {
                 $this->parameters = $parameters;
+
                 return true;
             }
         }
@@ -175,6 +177,29 @@ class RouteGroup extends Route implements IGroupRoute
     }
 
     /**
+     * When enabled group will overwrite any existing exception-handlers.
+     *
+     * @param bool $merge
+     * @return static
+     */
+    public function setMergeExceptionHandlers(bool $merge): self
+    {
+        $this->mergeExceptionHandlers = $merge;
+
+        return $this;
+    }
+
+    /**
+     * Returns true if group should overwrite existing exception-handlers.
+     *
+     * @return bool
+     */
+    public function getMergeExceptionHandlers(): bool
+    {
+        return $this->mergeExceptionHandlers;
+    }
+
+    /**
      * Merge with information from another route.
      *
      * @param array $settings
@@ -185,6 +210,10 @@ class RouteGroup extends Route implements IGroupRoute
     {
         if (isset($settings['prefix']) === true) {
             $this->setPrefix($settings['prefix'] . $this->prefix);
+        }
+
+        if (isset($settings['mergeExceptionHandlers']) === true) {
+            $this->setMergeExceptionHandlers($settings['mergeExceptionHandlers']);
         }
 
         if ($merge === false && isset($settings['exceptionHandler']) === true) {

--- a/src/Pecee/SimpleRouter/Route/RouteGroup.php
+++ b/src/Pecee/SimpleRouter/Route/RouteGroup.php
@@ -182,7 +182,7 @@ class RouteGroup extends Route implements IGroupRoute
      * @param bool $merge
      * @return static
      */
-    public function setMergeExceptionHandlers(bool $merge): self
+    public function setMergeExceptionHandlers(bool $merge): IGroupRoute
     {
         $this->mergeExceptionHandlers = $merge;
 

--- a/tests/Pecee/SimpleRouter/RouterRewriteTest.php
+++ b/tests/Pecee/SimpleRouter/RouterRewriteTest.php
@@ -33,9 +33,9 @@ class RouterRewriteTest extends \PHPUnit\Framework\TestCase
         global $stack;
         $stack = [];
 
-        TestRouter::group(['exceptionHandler' => [ExceptionHandlerFirst::class, ExceptionHandlerSecond::class]], function () use ($stack) {
+        TestRouter::group(['exceptionHandler' => [ExceptionHandlerFirst::class, ExceptionHandlerSecond::class]], function () {
 
-            TestRouter::group(['exceptionHandler' => ExceptionHandlerThird::class], function () use ($stack) {
+            TestRouter::group(['prefix' => '/test', 'exceptionHandler' => ExceptionHandlerThird::class], function () {
 
                 TestRouter::get('/my-path', 'DummyController@method1');
 
@@ -43,7 +43,7 @@ class RouterRewriteTest extends \PHPUnit\Framework\TestCase
         });
 
         try {
-            TestRouter::debug('/my-non-existing-path', 'get');
+            TestRouter::debug('/test/non-existing', 'get');
         } catch (\ResponseException $e) {
 
         }
@@ -56,6 +56,33 @@ class RouterRewriteTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals($expectedStack, $stack);
 
+    }
+
+    public function testStopMergeExceptionHandlers()
+    {
+        global $stack;
+        $stack = [];
+
+        TestRouter::group(['prefix' => '/', 'exceptionHandler' => ExceptionHandlerFirst::class], function () {
+
+            TestRouter::group(['prefix' => '/admin', 'exceptionHandler' => ExceptionHandlerSecond::class, 'mergeExceptionHandlers' => false], function () {
+
+                TestRouter::get('/my-path', 'DummyController@method1');
+
+            });
+        });
+
+        try {
+            TestRouter::debug('/admin/my-path-test', 'get');
+        } catch (\Pecee\SimpleRouter\Exceptions\NotFoundHttpException $e) {
+
+        }
+
+        $expectedStack = [
+            ExceptionHandlerSecond::class,
+        ];
+
+        $this->assertEquals($expectedStack, $stack);
     }
 
     public function testRewriteExceptionMessage()


### PR DESCRIPTION
- Added new Group attribute `mergeExceptionHandlers` to prevent router from merging inherited exception-handlers.
- `RouteGroup`: Added `setMergeExceptionHandlers` and `getMergeExceptionHandlers` methods.
- `IRouteGroup`: Added `setMergeExceptionHandlers` and `getMergeExceptionHandlers` method.
- Updated documentation to reflect changes.
- Added unit-tests.