### PR TITLE
Dynamic domain, fixed Subdomain

### DIFF
--- a/src/Pecee/SimpleRouter/Route/Route.php
+++ b/src/Pecee/SimpleRouter/Route/Route.php
@@ -123,7 +123,8 @@ abstract class Route implements IRoute
             );
 
         // Ensures that host names/domains will work with parameters
-        $url = '/' . ltrim($url, '/');
+        
+        if($route[0] == '{') $url = '/' . ltrim($url, '/');
         $urlRegex = '';
         $parameters = [];
 
@@ -131,7 +132,7 @@ abstract class Route implements IRoute
             $urlRegex = preg_quote($route, '/');
         } else {
 
-            foreach (preg_split('/((-?\/?){[^}]+})/', $route) as $key => $t) {
+            foreach (preg_split('/((\.?-?\/?){[^}]+})/', $route) as $key => $t) {
 
                 $regex = '';
 
@@ -146,7 +147,7 @@ abstract class Route implements IRoute
                         $regex = $parameterRegex ?? $this->defaultParameterRegex ?? static::PARAMETERS_DEFAULT_REGEX;
                     }
 
-                    $regex = sprintf('((\/|-)(?P<%2$s>%3$s))%1$s', $parameters[2][$key], $name, $regex);
+                    $regex = sprintf('((\/|-|\.)(?P<%2$s>%3$s))%1$s', $parameters[2][$key], $name, $regex);
                 }
 
                 $urlRegex .= preg_quote($t, '/') . $regex;

--- a/tests/Pecee/SimpleRouter/RouterRouteTest.php
+++ b/tests/Pecee/SimpleRouter/RouterRouteTest.php
@@ -177,6 +177,70 @@ class RouterRouteTest extends \PHPUnit\Framework\TestCase
 
         $this->assertFalse($result);
 
+    }    
+    
+    public function testFixedSubdomainDynamicDomain()
+    {
+        TestRouter::request()->setHost('other.world.com');
+
+        $result = false;
+
+        TestRouter::group(['domain' => 'other.{domain}'], function () use (&$result) {
+            TestRouter::get('/test', function ($domain = null) use (&$result) {
+
+                $result = true;
+            });
+        });
+
+        TestRouter::debug('/test', 'get');
+
+        $this->assertTrue($result);
+
+    }
+
+    public function testFixedSubdomainDynamicDomainParameter()
+    {
+        TestRouter::request()->setHost('other.world.com');
+
+        $result = false;
+
+        TestRouter::group(['domain' => 'other.{domain}'], function () use (&$result) {
+            TestRouter::get('/test', 'DummyController@param');
+            TestRouter::get('/test/{key}', 'DummyController@param');
+        });
+
+        $response = TestRouter::debugOutputnoReset('/test', 'get');
+
+        $this->assertEquals('world.com', $response);
+
+        $response = TestRouter::debugOutput('/test/unittest', 'get');
+
+        $this->assertEquals('unittest, world.com', $response);
+
+    }
+
+    public function testWrongFixedSubdomainDynamicDomain()
+    {
+        TestRouter::request()->setHost('wrong.world.com');
+
+        $result = false;
+
+        TestRouter::group(['domain' => 'other.{domain}'], function () use (&$result) {
+            TestRouter::get('/test', function ($domain = null) use (&$result) {
+
+                $result = true;
+            });
+        });
+
+        try {
+            TestRouter::debug('/test', 'get');
+        } catch(\Exception $e) {
+
+        }
+
+
+        $this->assertFalse($result);
+
     }
 
     public function testRegEx()

--- a/tests/Pecee/SimpleRouter/RouterRouteTest.php
+++ b/tests/Pecee/SimpleRouter/RouterRouteTest.php
@@ -209,7 +209,7 @@ class RouterRouteTest extends \PHPUnit\Framework\TestCase
             TestRouter::get('/test/{key}', 'DummyController@param');
         });
 
-        $response = TestRouter::debugOutputnoReset('/test', 'get');
+        $response = TestRouter::debugOutputNoReset('/test', 'get');
 
         $this->assertEquals('world.com', $response);
 

--- a/tests/TestRouter.php
+++ b/tests/TestRouter.php
@@ -48,4 +48,17 @@ class TestRouter extends \Pecee\SimpleRouter\SimpleRouter
         return $response;
     }
 
+    public static function debugOutputNoReset(string $testUrl, string $testMethod = 'get', bool $reset = true): string
+    {
+        $response = null;
+
+        // Route request
+        ob_start();
+        static::debugNoReset($testUrl, $testMethod, $reset);
+        $response = ob_get_clean();
+
+        // Return response
+        return $response;
+    }
+
 }


### PR DESCRIPTION
We need the feature to use a fixed subdomain and get the domain as dynamic parameter.
Implementation was easy: We added the dot as separator before parameters.

With another modification, We are not fully sure, if there are side effects. All tests passes.
Now we only add a slash add beginning of $url, when the route start with a parameter.

I don't think there are side effects, because the prefix slash is only need to match on routes, which start with a parameter. Otherwise there are existing separators in url.
But it is not fully clear, why a separator is needed, because regular expressions also match without one. 

We would adjust the solution, depending on feedback. 

To check all options, we need a "debugOutputNoReset" function in TestRouter, we also commit.