### PR TITLE
Make current processing rule accessible

### DIFF
--- a/src/Pecee/SimpleRouter/Router.php
+++ b/src/Pecee/SimpleRouter/Router.php
@@ -35,6 +35,12 @@ class Router
      * @var bool
      */
     protected $isProcessingRoute;
+    
+    /**
+     * Defines all data from current processing route.
+     * @var array
+     */
+    protected $currentProcessingRoute = [];
 
     /**
      * All added routes
@@ -371,6 +377,9 @@ class Router
             foreach ($this->processedRoutes as $key => $route) {
 
                 $this->debug('Matching route "%s"', get_class($route));
+                
+                /* Add current processing route to constants */
+                $this->currentProcessingRoute = $route;
 
                 /* If the route matches */
                 if ($route->matchRoute($url, $this->request) === true) {
@@ -429,6 +438,9 @@ class Router
                     }
                 }
             }
+            
+            /* Remove the current processing route after handle all possible routes */
+            $this->currentProcessingRoute = [];
 
         } catch (Exception $e) {
             $this->handleException($e);

--- a/src/Pecee/SimpleRouter/Router.php
+++ b/src/Pecee/SimpleRouter/Router.php
@@ -38,9 +38,9 @@ class Router
     
     /**
      * Defines all data from current processing route.
-     * @var array
+     * @var ILoadableRoute
      */
-    protected $currentProcessingRoute = [];
+    protected $currentProcessingRoute;
 
     /**
      * All added routes
@@ -438,9 +438,6 @@ class Router
                     }
                 }
             }
-            
-            /* Remove the current processing route after handle all possible routes */
-            $this->currentProcessingRoute = [];
 
         } catch (Exception $e) {
             $this->handleException($e);
@@ -943,9 +940,9 @@ class Router
     /**
      * Get the current processing route details.
      *
-     * @return array
+     * @return ILoadableRoute
      */
-    public function getCurrentProcessingRoute(): array
+    public function getCurrentProcessingRoute(): ILoadableRoute
     {
         return $this->currentProcessingRoute;
     }

--- a/src/Pecee/SimpleRouter/Router.php
+++ b/src/Pecee/SimpleRouter/Router.php
@@ -939,6 +939,16 @@ class Router
     {
         return $this->debugList;
     }
+    
+    /**
+     * Get the current processing route details.
+     *
+     * @return array
+     */
+    public function getCurrentProcessingRoute(): array
+    {
+        return $this->currentProcessingRoute;
+    }
 
     /**
      * Changes the rendering behavior of the router.


### PR DESCRIPTION
With this PR i want to resolve my bad solution from #598 

I added a new global variable which will contains the current processing rule while processing. So the data (like rule name) are usable in the middleware:

```php
namespace My\Router\Namespace;

use Pecee\Http\Middleware\IMiddleware;
use Pecee\Http\Request;
use Pecee\SimpleRouter\SimpleRouter as Router;

class test implements IMiddleware
{
	public function handle(Request $request) : void
	{
		$router = Router::router();
		$RouteName = $router->getCurrentProcessingRoute()->getName();
	}
}
```

Thanks for merging.

Kind regards