### PR TITLE
json_decode is null on error

### DIFF
--- a/src/Pecee/Http/Input/InputHandler.php
+++ b/src/Pecee/Http/Input/InputHandler.php
@@ -79,7 +79,7 @@ class InputHandler
             if (strpos(trim($contents), '{') === 0) {
                 $post = json_decode($contents, true);
 
-                if ($post !== false) {
+                if ($post !== null) {
                     $this->originalPost += $post;
                 }
             }


### PR DESCRIPTION
Hello @skipperbent,

thanks to the issue #599 reported by @vrgblzs I changed `if ($post !== false) {` to `if ($post !== null) {`.

~ Marius