### PR TITLE
print return callback by ExceptionHandler

### DIFF
--- a/src/Pecee/SimpleRouter/Router.php
+++ b/src/Pecee/SimpleRouter/Router.php
@@ -431,12 +431,18 @@ class Router
             }
 
         } catch (Exception $e) {
-            $this->handleException($e);
+            $output = $this->handleException($e);
+            if ($output !== null) {
+                return $output;
+            }
         }
 
         if ($methodNotAllowed === true) {
             $message = sprintf('Route "%s" or method "%s" not allowed.', $this->request->getUrl()->getPath(), $this->request->getMethod());
-            $this->handleException(new NotFoundHttpException($message, 403));
+            $output = $this->handleException(new NotFoundHttpException($message, 403));
+            if ($output !== null) {
+                return $output;
+            }
         }
 
         if (count($this->request->getLoadedRoutes()) === 0) {


### PR DESCRIPTION
Hello @skipperbent,

thanks to the Issue #606 by @riku22, after some deep debugging, I was able to discover two cases, where the rewriteCallback return value is ignored and therefor not printed as the output.

The first case was like I sayed discovered by #606:
When you rewrite the callback in an errorHandler, the return value is not printed as the output.
https://github.com/skipperbent/simple-php-router/blob/13fbbc88c23d00807b2883b6e2b65180f47b5871/src/Pecee/SimpleRouter/Router.php#L434-L437

The second case is very similar. This takes place when the wrong request method is used but the route exists.
In this case there is the same error occurs.
https://github.com/skipperbent/simple-php-router/blob/13fbbc88c23d00807b2883b6e2b65180f47b5871/src/Pecee/SimpleRouter/Router.php#L442-L445

@skipperbent please merge.

~ Marius