### PR TITLE
PHP8: better exception handling

### DIFF
--- a/src/Pecee/SimpleRouter/Router.php
+++ b/src/Pecee/SimpleRouter/Router.php
@@ -35,7 +35,7 @@ class Router
      * @var bool
      */
     protected bool $isProcessingRoute;
-    
+
     /**
      * Defines all data from current processing route.
      * @var ILoadableRoute
@@ -59,7 +59,7 @@ class Router
      * when a route is being processed.
      * @var array
      */
-    protected array$routeStack = [];
+    protected array $routeStack = [];
 
     /**
      * List of added bootmanagers
@@ -166,7 +166,7 @@ class Router
     public function addRoute(IRoute $route): IRoute
     {
         $this->fireEvents(EventHandler::EVENT_ADD_ROUTE, [
-            'route'      => $route,
+            'route' => $route,
             'isSubRoute' => $this->isProcessingRoute,
         ]);
 
@@ -307,7 +307,7 @@ class Router
             $this->debug('Rendering bootmanager "%s"', $className);
             $this->fireEvents(EventHandler::EVENT_RENDER_BOOTMANAGER, [
                 'bootmanagers' => $this->bootManagers,
-                'bootmanager'  => $manager,
+                'bootmanager' => $manager,
             ]);
 
             /* Render bootmanager */
@@ -345,7 +345,7 @@ class Router
             try {
                 /* Verify csrf token for request */
                 $this->csrfVerifier->handle($this->request);
-            } catch(Exception $e) {
+            } catch (Exception $e) {
                 return $this->handleException($e);
             }
         }
@@ -381,7 +381,7 @@ class Router
             foreach ($this->processedRoutes as $key => $route) {
 
                 $this->debug('Matching route "%s"', get_class($route));
-                
+
                 /* Add current processing route to constants */
                 $this->currentProcessingRoute = $route;
 
@@ -405,7 +405,7 @@ class Router
                     }
 
                     $this->fireEvents(EventHandler::EVENT_RENDER_MIDDLEWARES, [
-                        'route'       => $route,
+                        'route' => $route,
                         'middlewares' => $route->getMiddlewares(),
                     ]);
 
@@ -443,8 +443,12 @@ class Router
                 }
             }
 
-        } catch (Exception $e) {
-            return $this->handleException($e);
+        } catch (\Throwable $e) {
+            if ($e instanceof Exception) {
+                return $this->handleException($e);
+            }
+
+            return $this->handleException(new Exception($e->getMessage(), $e->getCode()));
         }
 
         if ($methodNotAllowed === true) {
@@ -500,7 +504,7 @@ class Router
             $this->request->setHasPendingRewrite(false);
 
             $this->fireEvents(EventHandler::EVENT_REWRITE, [
-                'rewriteUrl'   => $this->request->getRewriteUrl(),
+                'rewriteUrl' => $this->request->getRewriteUrl(),
                 'rewriteRoute' => $this->request->getRewriteRoute(),
             ]);
 
@@ -521,7 +525,7 @@ class Router
         $this->debug('Starting exception handling for "%s"', get_class($e));
 
         $this->fireEvents(EventHandler::EVENT_LOAD_EXCEPTIONS, [
-            'exception'         => $e,
+            'exception' => $e,
             'exceptionHandlers' => $this->exceptionHandlers,
         ]);
 
@@ -533,8 +537,8 @@ class Router
             }
 
             $this->fireEvents(EventHandler::EVENT_RENDER_EXCEPTION, [
-                'exception'         => $e,
-                'exceptionHandler'  => $handler,
+                'exception' => $e,
+                'exceptionHandler' => $handler,
                 'exceptionHandlers' => $this->exceptionHandlers,
             ]);
 
@@ -556,7 +560,7 @@ class Router
                     $this->debug('Exception handler contains rewrite, reloading routes');
 
                     $this->fireEvents(EventHandler::EVENT_REWRITE, [
-                        'rewriteUrl'   => $this->request->getRewriteUrl(),
+                        'rewriteUrl' => $this->request->getRewriteUrl(),
                         'rewriteRoute' => $this->request->getRewriteRoute(),
                     ]);
 
@@ -667,9 +671,9 @@ class Router
         $this->debug('Finding url', func_get_args());
 
         $this->fireEvents(EventHandler::EVENT_GET_URL, [
-            'name'       => $name,
+            'name' => $name,
             'parameters' => $parameters,
-            'getParams'  => $getParams,
+            'getParams' => $getParams,
         ]);
 
         if ($name === '' && $parameters === '') {
@@ -913,8 +917,8 @@ class Router
         $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
         $this->debugList[] = [
             'message' => vsprintf($message, $args),
-            'time'    => number_format(microtime(true) - $this->debugStartTime, 10),
-            'trace'   => end($trace),
+            'time' => number_format(microtime(true) - $this->debugStartTime, 10),
+            'trace' => end($trace),
         ];
     }
 
@@ -940,7 +944,7 @@ class Router
     {
         return $this->debugList;
     }
-    
+
     /**
      * Get the current processing route details.
      *


### PR DESCRIPTION
Looks like PHP8 handles exceptions differently with Throwables used in cases where php-error occoured. To fix this Throwable are now used to catch exception in routeRequest and any instance of Throwable will be converted to Exception.