### PR TITLE
Fixed Route::setUrl() behavior

### DIFF
--- a/src/Pecee/SimpleRouter/Route/LoadableRoute.php
+++ b/src/Pecee/SimpleRouter/Route/LoadableRoute.php
@@ -82,14 +82,16 @@ abstract class LoadableRoute extends Route implements ILoadableRoute
     {
         $this->url = ($url === '/') ? '/' : '/' . trim($url, '/') . '/';
 
+        $parameters = [];
         if (strpos($this->url, $this->paramModifiers[0]) !== false) {
 
             $regex = sprintf(static::PARAMETERS_REGEX_FORMAT, $this->paramModifiers[0], $this->paramOptionalSymbol, $this->paramModifiers[1]);
 
             if ((bool)preg_match_all('/' . $regex . '/u', $this->url, $matches) !== false) {
-                $this->parameters = array_fill_keys($matches[1], null);
+                $parameters = array_fill_keys($matches[1], null);
             }
         }
+        $this->parameters = $parameters;
 
         return $this;
     }

--- a/tests/Pecee/SimpleRouter/Dummy/Route/DummyLoadableRoute.php
+++ b/tests/Pecee/SimpleRouter/Dummy/Route/DummyLoadableRoute.php
@@ -1,0 +1,11 @@
+<?php
+
+use Pecee\Http\Request;
+
+class DummyLoadableRoute extends Pecee\SimpleRouter\Route\LoadableRoute {
+
+    public function matchRoute(string $url, Request $request): bool
+    {
+        return false;
+    }
+}

--- a/tests/Pecee/SimpleRouter/LoadableRouteTest.php
+++ b/tests/Pecee/SimpleRouter/LoadableRouteTest.php
@@ -1,0 +1,27 @@
+<?php
+
+require_once 'Dummy/Route/DummyLoadableRoute.php';
+
+class LoadableRouteTest extends \PHPUnit\Framework\TestCase
+{
+    public function testSetUrlUpdatesParameters()
+    {
+        $route = new DummyLoadableRoute();
+        $this->assertEmpty($route->getParameters());
+
+        $route->setUrl('/');
+        $this->assertEmpty($route->getParameters());
+
+        $expected = ['param' => null, 'optionalParam' => null];
+        $route->setUrl('/{param}/{optionalParam?}');
+        $this->assertEquals($expected, $route->getParameters());
+
+        $expected = ['otherParam' => null];
+        $route->setUrl('/{otherParam}');
+        $this->assertEquals($expected, $route->getParameters());
+
+        $expected = [];
+        $route->setUrl('/');
+        $this->assertEquals($expected, $route->getParameters());
+    }
+}


### PR DESCRIPTION
When there are no parameters in the url, correctly empty the routes parameter array.

Fixes #663