### PR TITLE
Version 5.3.0.4

### DIFF
--- a/src/Pecee/SimpleRouter/Route/LoadableRoute.php
+++ b/src/Pecee/SimpleRouter/Route/LoadableRoute.php
@@ -82,14 +82,16 @@ abstract class LoadableRoute extends Route implements ILoadableRoute
     {
         $this->url = ($url === '/') ? '/' : '/' . trim($url, '/') . '/';
 
+        $parameters = [];
         if (strpos($this->url, $this->paramModifiers[0]) !== false) {
 
             $regex = sprintf(static::PARAMETERS_REGEX_FORMAT, $this->paramModifiers[0], $this->paramOptionalSymbol, $this->paramModifiers[1]);
 
             if ((bool)preg_match_all('/' . $regex . '/u', $this->url, $matches) !== false) {
-                $this->parameters = array_fill_keys($matches[1], null);
+                $parameters = array_fill_keys($matches[1], null);
             }
         }
+        $this->parameters = $parameters;
 
         return $this;
     }

--- a/src/Pecee/SimpleRouter/Route/RouteResource.php
+++ b/src/Pecee/SimpleRouter/Route/RouteResource.php
@@ -7,22 +7,22 @@ use Pecee\Http\Request;
 class RouteResource extends LoadableRoute implements IControllerRoute
 {
     protected array $urls = [
-        'index'   => '',
-        'create'  => 'create',
-        'store'   => '',
-        'show'    => '',
-        'edit'    => 'edit',
-        'update'  => '',
+        'index' => '',
+        'create' => 'create',
+        'store' => '',
+        'show' => '',
+        'edit' => 'edit',
+        'update' => '',
         'destroy' => '',
     ];
 
     protected array $methodNames = [
-        'index'   => 'index',
-        'create'  => 'create',
-        'store'   => 'store',
-        'show'    => 'show',
-        'edit'    => 'edit',
-        'update'  => 'update',
+        'index' => 'index',
+        'create' => 'create',
+        'store' => 'store',
+        'show' => 'show',
+        'edit' => 'edit',
+        'update' => 'update',
         'destroy' => 'destroy',
     ];
 
@@ -68,12 +68,15 @@ class RouteResource extends LoadableRoute implements IControllerRoute
      */
     public function findUrl(?string $method = null, $parameters = null, ?string $name = null): string
     {
-        $url = array_search($name, $this->names, true);
-        if ($url !== false) {
-            return rtrim($this->url . $this->urls[$url], '/') . '/';
+        $url = parent::findUrl($method, $parameters, $name);
+
+        $action = array_search($name, $this->names, true);
+
+        if ($action !== false) {
+            return $url . $this->urls[$action];
         }
 
-        return $this->url;
+        return $url;
     }
 
     protected function call($method): bool
@@ -172,12 +175,12 @@ class RouteResource extends LoadableRoute implements IControllerRoute
         $this->name = $name;
 
         $this->names = [
-            'index'   => $this->name . '.index',
-            'create'  => $this->name . '.create',
-            'store'   => $this->name . '.store',
-            'show'    => $this->name . '.show',
-            'edit'    => $this->name . '.edit',
-            'update'  => $this->name . '.update',
+            'index' => $this->name . '.index',
+            'create' => $this->name . '.create',
+            'store' => $this->name . '.store',
+            'show' => $this->name . '.show',
+            'edit' => $this->name . '.edit',
+            'update' => $this->name . '.update',
             'destroy' => $this->name . '.destroy',
         ];
 

--- a/src/Pecee/SimpleRouter/Router.php
+++ b/src/Pecee/SimpleRouter/Router.php
@@ -444,7 +444,7 @@ class Router
             }
 
         } catch (Exception $e) {
-            return $this->handleException(new Exception($e->getMessage(), $e->getCode()));
+            return $this->handleException($e);
         }
 
         if ($methodNotAllowed === true) {

--- a/src/Pecee/SimpleRouter/Router.php
+++ b/src/Pecee/SimpleRouter/Router.php
@@ -443,11 +443,7 @@ class Router
                 }
             }
 
-        } catch (\Throwable $e) {
-            if ($e instanceof Exception) {
-                return $this->handleException($e);
-            }
-
+        } catch (Exception $e) {
             return $this->handleException(new Exception($e->getMessage(), $e->getCode()));
         }
 

--- a/tests/Pecee/SimpleRouter/Dummy/Route/DummyLoadableRoute.php
+++ b/tests/Pecee/SimpleRouter/Dummy/Route/DummyLoadableRoute.php
@@ -1,0 +1,11 @@
+<?php
+
+use Pecee\Http\Request;
+
+class DummyLoadableRoute extends Pecee\SimpleRouter\Route\LoadableRoute {
+
+    public function matchRoute(string $url, Request $request): bool
+    {
+        return false;
+    }
+}

--- a/tests/Pecee/SimpleRouter/LoadableRouteTest.php
+++ b/tests/Pecee/SimpleRouter/LoadableRouteTest.php
@@ -1,0 +1,27 @@
+<?php
+
+require_once 'Dummy/Route/DummyLoadableRoute.php';
+
+class LoadableRouteTest extends \PHPUnit\Framework\TestCase
+{
+    public function testSetUrlUpdatesParameters()
+    {
+        $route = new DummyLoadableRoute();
+        $this->assertEmpty($route->getParameters());
+
+        $route->setUrl('/');
+        $this->assertEmpty($route->getParameters());
+
+        $expected = ['param' => null, 'optionalParam' => null];
+        $route->setUrl('/{param}/{optionalParam?}');
+        $this->assertEquals($expected, $route->getParameters());
+
+        $expected = ['otherParam' => null];
+        $route->setUrl('/{otherParam}');
+        $this->assertEquals($expected, $route->getParameters());
+
+        $expected = [];
+        $route->setUrl('/');
+        $this->assertEquals($expected, $route->getParameters());
+    }
+}

--- a/tests/Pecee/SimpleRouter/RouterResourceTest.php
+++ b/tests/Pecee/SimpleRouter/RouterResourceTest.php
@@ -66,4 +66,20 @@ class RouterResourceTest extends \PHPUnit\Framework\TestCase
 
     }
 
+    public function testResourceUrls()
+    {
+        TestRouter::resource('/resource', 'ResourceController')->name('resource');
+
+        TestRouter::debugOutputNoReset('/resource');
+
+        $this->assertEquals('/resource/3/create/', TestRouter::router()->getUrl('resource.create', ['id' => 3]));
+        $this->assertEquals('/resource/3/edit/', TestRouter::router()->getUrl('resource.edit', ['id' => 3]));
+        $this->assertEquals('/resource/3/', TestRouter::router()->getUrl('resource.update', ['id' => 3]));
+        $this->assertEquals('/resource/3/', TestRouter::router()->getUrl('resource.destroy', ['id' => 3]));
+        $this->assertEquals('/resource/3/', TestRouter::router()->getUrl('resource.delete', ['id' => 3]));
+        $this->assertEquals('/resource/', TestRouter::router()->getUrl('resource'));
+
+        TestRouter::router()->reset();
+    }
+
 }


### PR DESCRIPTION
- Fix setUrl: When there are no parameters in the url, correctly empty the routes parameter array (issue: #663)
- Fixed: Resource-route not respecting parameters when using getUrl (issue: #666)
- Added more unit-tests.