### PR TITLE
Added @return never to Response.php

### DIFF
--- a/src/Pecee/Http/Response.php
+++ b/src/Pecee/Http/Response.php
@@ -32,6 +32,8 @@ class Response
      *
      * @param string $url
      * @param ?int $httpCode
+     *
+     * @return never
      */
     public function redirect(string $url, ?int $httpCode = null): void
     {


### PR DESCRIPTION
In PHP8.1 instead of :void :never would be returned. As this project is PHP7.4 compatible, we add it as a PHPDOC, so IDEs using this project will no longer complain and automatic checks will successfully detect dead code after calling a redirect()