### PR TITLE
Fixed php-di class loader example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1742,7 +1742,7 @@ SimpleRouter::setCustomClassLoader(new MyCustomClassLoader());
 php-di support was discontinued by version 4.3, however you can easily add it again by creating your own class-loader like the example below:
 
 ```php
-use Pecee\SimpleRouter\Exceptions\ClassNotFoundHttpException;
+use Pecee\SimpleRouter\Exceptions\NotFoundHttpException;
 
 class MyCustomClassLoader implements IClassLoader
 {


### PR DESCRIPTION
In the previous version of the README, the example custom php-di class loader was importing the wrong exception (ClassNotFoundHttpException), while a different exception (NotFoundHttpException) is being used in the code, causing the code to not work.