### PR TITLE
Fixed the php-di integration example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1742,6 +1742,7 @@ SimpleRouter::setCustomClassLoader(new MyCustomClassLoader());
 php-di support was discontinued by version 4.3, however you can easily add it again by creating your own class-loader like the example below:
 
 ```php
+use Pecee\SimpleRouter\ClassLoader\IClassLoader;
 use Pecee\SimpleRouter\Exceptions\ClassNotFoundHttpException;
 
 class MyCustomClassLoader implements IClassLoader
@@ -1762,19 +1763,14 @@ class MyCustomClassLoader implements IClassLoader
      *
      * @param string $class
      * @return object
-     * @throws NotFoundHttpException
+     * @throws ClassNotFoundHttpException
      */
     public function loadClass(string $class)
     {
-        if (class_exists($class) === false) {
-            throw new NotFoundHttpException(sprintf('Class "%s" does not exist', $class), 404);
+        if ($this->container->has($class) === false) {
+            throw new ClassNotFoundHttpException($class, null, sprintf('Class "%s" does not exist', $class), 404, null);
         }
-
-		try {
-			return $this->container->get($class);
-		} catch (\Exception $e) {
-			throw new NotFoundHttpException($e->getMessage(), (int)$e->getCode(), $e->getPrevious());
-		}
+        return $this->container->get($class);
     }
     
     /**
@@ -1782,15 +1778,11 @@ class MyCustomClassLoader implements IClassLoader
      * @param object $class
      * @param string $method
      * @param array $parameters
-     * @return object
+     * @return string
      */
     public function loadClassMethod($class, string $method, array $parameters)
     {
-		try {
-			return $this->container->call([$class, $method], $parameters);
-		} catch (\Exception $e) {
-			throw new NotFoundHttpException($e->getMessage(), (int)$e->getCode(), $e->getPrevious());
-		}
+        return (string)$this->container->call([$class, $method], $parameters);
     }
 
     /**
@@ -1798,15 +1790,11 @@ class MyCustomClassLoader implements IClassLoader
      *
      * @param Callable $closure
      * @param array $parameters
-     * @return mixed
+     * @return string
      */
     public function loadClosure(callable $closure, array $parameters)
     {
-		try {
-			return $this->container->call($closure, $parameters);
-		} catch (\Exception $e) {
-			throw new NotFoundHttpException($e->getMessage(), (int)$e->getCode(), $e->getPrevious());
-		}
+        return (string)$this->container->call($closure, $parameters);
     }
 }
 ```


### PR DESCRIPTION
I've adapted the example to be similar to the current version of Pecee\SimpleRouter\ClassLoader\ClassLoader. That includes returning strings from loadClassMethod and loadClosure and not wrapping every exception, thrown by the called functions, into NotFoundHttpException exceptions, as well as using the exception ClassNotFoundHttpException when a class cannot be found, instead of the generic NotFoundHttpException (that was not even being imported in the previous version). I also changed the way the ClassLoader checks if the container can resolve the class by using the container's method "has" instead of the php function class_exists.