### PR TITLE
Version 5.4.1.0

### DIFF
--- a/src/Pecee/Http/Request.php
+++ b/src/Pecee/Http/Request.php
@@ -130,9 +130,9 @@ class Request
 
         // Check if special IIS header exist, otherwise use default.
         $url = $this->getHeader('unencoded-url');
-        if($url !== null){
+        if ($url !== null) {
             $this->setUrl(new Url($url));
-        }else{
+        } else {
             $this->setUrl(new Url(urldecode((string)$this->getHeader('request-uri'))));
         }
         $this->setContentType((string)$this->getHeader('content-type'));
@@ -225,7 +225,7 @@ class Request
     public function getIp(bool $safeMode = false): ?string
     {
         $headers = [];
-        if($safeMode === false) {
+        if ($safeMode === false) {
             $headers = [
                 'http-cf-connecting-ip',
                 'http-client-ip',
@@ -303,9 +303,9 @@ class Request
      */
     public function getFirstHeader(array $headers, $defaultValue = null)
     {
-        foreach($headers as $header) {
+        foreach ($headers as $header) {
             $header = $this->getHeader($header);
-            if($header !== null) {
+            if ($header !== null) {
                 return $header;
             }
         }
@@ -329,7 +329,7 @@ class Request
      */
     protected function setContentType(string $contentType): self
     {
-        if(strpos($contentType, ';') > 0) {
+        if (strpos($contentType, ';') > 0) {
             $this->contentType = strtolower(substr($contentType, 0, strpos($contentType, ';')));
         } else {
             $this->contentType = strtolower($contentType);
@@ -371,7 +371,7 @@ class Request
 
     /**
      * Returns true when request-method is type that could contain data in the page body.
-     * 
+     *
      * @return bool
      */
     public function isPostBack(): bool
@@ -395,11 +395,11 @@ class Request
     {
         $this->url = $url;
 
-        if ($this->url->getHost() === null) {
+        if ($this->url->getHost() === null && $this->getHost() !== null) {
             $this->url->setHost((string)$this->getHost());
         }
 
-        if($this->isSecure() === true) {
+        if ($this->isSecure() === true) {
             $this->url->setScheme('https');
         }
     }

--- a/src/Pecee/Http/Url.php
+++ b/src/Pecee/Http/Url.php
@@ -67,7 +67,11 @@ class Url implements JsonSerializable
     public function __construct(?string $url)
     {
         $this->originalUrl = $url;
+        $this->parse($url, true);
+    }
 
+    public function parse(?string $url, bool $setOriginalPath = false): self
+    {
         if ($url !== null && $url !== '/') {
             $data = $this->parseUrl($url);
 
@@ -79,7 +83,10 @@ class Url implements JsonSerializable
 
             if (isset($data['path']) === true) {
                 $this->setPath($data['path']);
-                $this->originalPath = $data['path'];
+
+                if ($setOriginalPath === true) {
+                    $this->originalPath = $data['path'];
+                }
             }
 
             $this->fragment = $data['fragment'] ?? null;
@@ -88,6 +95,7 @@ class Url implements JsonSerializable
                 $this->setQueryString($data['query']);
             }
         }
+        return $this;
     }
 
     /**

--- a/src/Pecee/SimpleRouter/Route/LoadableRoute.php
+++ b/src/Pecee/SimpleRouter/Route/LoadableRoute.php
@@ -6,6 +6,7 @@ use Pecee\Http\Middleware\IMiddleware;
 use Pecee\Http\Request;
 use Pecee\SimpleRouter\Exceptions\HttpException;
 use Pecee\SimpleRouter\Router;
+use Pecee\SimpleRouter\SimpleRouter;
 
 abstract class LoadableRoute extends Route implements ILoadableRoute
 {
@@ -138,12 +139,6 @@ abstract class LoadableRoute extends Route implements ILoadableRoute
     {
         $url = $this->getUrl();
 
-        $group = $this->getGroup();
-
-        if ($group !== null && count($group->getDomains()) !== 0) {
-            $url = '//' . $group->getDomains()[0] . $url;
-        }
-
         /* Create the param string - {parameter} */
         $param1 = $this->paramModifiers[0] . '%s' . $this->paramModifiers[1];
 
@@ -177,7 +172,15 @@ abstract class LoadableRoute extends Route implements ILoadableRoute
             }
         }
 
-        return rtrim('/' . ltrim($url, '/'), '/') . '/';
+        $url = rtrim('/' . ltrim($url, '/'), '/') . '/';
+
+        $group = $this->getGroup();
+
+        if ($group !== null && count($group->getDomains()) !== 0 && SimpleRouter::request()->getHost() !== $group->getDomains()[0]) {
+            $url = '//' . $group->getDomains()[0] . $url;
+        }
+
+        return $url;
     }
 
     /**

--- a/src/Pecee/SimpleRouter/Route/RouteController.php
+++ b/src/Pecee/SimpleRouter/Route/RouteController.php
@@ -3,6 +3,7 @@
 namespace Pecee\SimpleRouter\Route;
 
 use Pecee\Http\Request;
+use Pecee\SimpleRouter\SimpleRouter;
 
 class RouteController extends LoadableRoute implements IControllerRoute
 {
@@ -77,13 +78,15 @@ class RouteController extends LoadableRoute implements IControllerRoute
 
         $group = $this->getGroup();
 
-        if ($group !== null && count($group->getDomains()) !== 0) {
-            $url .= '//' . $group->getDomains()[0];
-        }
-
         $url .= '/' . trim($this->getUrl(), '/') . '/' . strtolower((string)$method) . implode('/', $parameters);
 
-        return '/' . trim($url, '/') . '/';
+        $url = '/' . trim($url, '/') . '/';
+
+        if ($group !== null && count($group->getDomains()) !== 0 && SimpleRouter::request()->getHost() !== $group->getDomains()[0]) {
+            $url = '//' . $group->getDomains()[0] . $url;
+        }
+
+        return $url;
     }
 
     public function matchRoute(string $url, Request $request): bool

--- a/src/Pecee/SimpleRouter/Route/RouteGroup.php
+++ b/src/Pecee/SimpleRouter/Route/RouteGroup.php
@@ -220,7 +220,7 @@ class RouteGroup extends Route implements IGroupRoute
             $this->setExceptionHandlers((array)$settings['exceptionHandler']);
         }
 
-        if ($merge === false && isset($settings['domain']) === true) {
+        if (isset($settings['domain']) === true) {
             $this->setDomains((array)$settings['domain']);
         }
 

--- a/src/Pecee/SimpleRouter/Route/RouteResource.php
+++ b/src/Pecee/SimpleRouter/Route/RouteResource.php
@@ -3,6 +3,7 @@
 namespace Pecee\SimpleRouter\Route;
 
 use Pecee\Http\Request;
+use Pecee\SimpleRouter\SimpleRouter;
 
 class RouteResource extends LoadableRoute implements IControllerRoute
 {
@@ -80,7 +81,14 @@ class RouteResource extends LoadableRoute implements IControllerRoute
             return rtrim($this->url . $parametersUrl . $this->urls[$url], '/') . '/';
         }
 
-        return $this->url . $parametersUrl;
+        $url = $this->url . $parametersUrl;
+
+        $group = $this->getGroup();
+        if ($group !== null && count($group->getDomains()) !== 0 && SimpleRouter::request()->getHost() !== $group->getDomains()[0]) {
+            $url = '//' . $group->getDomains()[0] . $url;
+        }
+
+        return $url;
     }
 
     protected function call($method): bool

--- a/src/Pecee/SimpleRouter/Router.php
+++ b/src/Pecee/SimpleRouter/Router.php
@@ -691,10 +691,7 @@ class Router
 
         /* If nothing is defined and a route is loaded we use that */
         if ($name === null && $loadedRoute !== null) {
-            return $this->request
-                ->getUrlCopy()
-                ->setPath($loadedRoute->findUrl($loadedRoute->getMethod(), $parameters, $name))
-                ->setParams($getParams);
+            return $this->request->getUrlCopy()->parse($loadedRoute->findUrl($loadedRoute->getMethod(), $parameters, $name))->setParams($getParams);
         }
 
         if ($name !== null) {
@@ -702,10 +699,7 @@ class Router
             $route = $this->findRoute($name);
 
             if ($route !== null) {
-                return $this->request
-                    ->getUrlCopy()
-                    ->setPath($route->findUrl($route->getMethod(), $parameters, $name))
-                    ->setParams($getParams);
+                return $this->request->getUrlCopy()->parse($route->findUrl($route->getMethod(), $parameters, $name))->setParams($getParams);
             }
         }
 
@@ -720,18 +714,12 @@ class Router
 
                 /* Check if the route contains the name/alias */
                 if ($processedRoute->hasName($controller) === true) {
-                    return $this->request
-                        ->getUrlCopy()
-                        ->setPath($processedRoute->findUrl($method, $parameters, $name))
-                        ->setParams($getParams);
+                    return $this->request->getUrlCopy()->parse($processedRoute->findUrl($method, $parameters, $name))->setParams($getParams);
                 }
 
                 /* Check if the route controller is equal to the name */
                 if ($processedRoute instanceof IControllerRoute && strtolower($processedRoute->getController()) === strtolower($controller)) {
-                    return $this->request
-                        ->getUrlCopy()
-                        ->setPath($processedRoute->findUrl($method, $parameters, $name))
-                        ->setParams($getParams);
+                    return $this->request->getUrlCopy()->parse($processedRoute->findUrl($method, $parameters, $name))->setParams($getParams);
                 }
 
             }
@@ -741,10 +729,7 @@ class Router
         $url = trim(implode('/', array_merge((array)$name, (array)$parameters)), '/');
         $url = (($url === '') ? '/' : '/' . $url . '/');
 
-        return $this->request
-            ->getUrlCopy()
-            ->setPath($url)
-            ->setParams($getParams);
+        return $this->request->getUrlCopy()->parse($url)->setParams($getParams);
     }
 
     /**

--- a/tests/Pecee/SimpleRouter/RouterUrlTest.php
+++ b/tests/Pecee/SimpleRouter/RouterUrlTest.php
@@ -94,10 +94,12 @@ class RouterUrlTest extends \PHPUnit\Framework\TestCase
 
     public function testSimilarUrls()
     {
+        TestRouter::reset();
         // Match normal route on alias
         TestRouter::get('/url11', 'DummyController@method1');
         TestRouter::get('/url22', 'DummyController@method2');
         TestRouter::get('/url33', 'DummyController@method2')->name('match');
+
 
         TestRouter::debugNoReset('/url33', 'get');
 

--- a/tests/TestRouter.php
+++ b/tests/TestRouter.php
@@ -17,7 +17,7 @@ class TestRouter extends \Pecee\SimpleRouter\SimpleRouter
     {
         $request = static::request();
 
-        $request->setUrl((new \Pecee\Http\Url($testUrl))->setHost('local.unitTest'));
+        $request->setUrl((new \Pecee\Http\Url($testUrl)));
         $request->setMethod($testMethod);
 
         static::start();


### PR DESCRIPTION
- Fixed domains not being prepending properly to urls.
- Won't prepend subdomain to urls if subdomain is equal to current host.
- Url: implemented parse function.
- Router: getUrl now parses url to properly parse the subdomain.