### PR TITLE
Add support for handling CORS preflight requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ You can donate any amount of your choice by [clicking here](https://www.paypal.c
         - [Required parameters](#required-parameters)
         - [Optional parameters](#optional-parameters)
         - [Including slash in parameters](#including-slash-in-parameters)
+        - [Handling CORS Preflight Requests](#handling-cors-preflight-requests)
         - [Regular expression constraints](#regular-expression-constraints)
         - [Regular expression route-match](#regular-expression-route-match)
         - [Custom regex for matching parameters](#custom-regex-for-matching-parameters)
@@ -512,6 +513,29 @@ SimpleRouter::get('/path/{fileOrFolder}', function ($fileOrFolder) {
 
 - Requesting `/path/file` will return the `$fileOrFolder` value: `file`.
 - Requesting `/path/folder/` will return the `$fileOrFolder` value: `folder/`.
+
+### Handling CORS Preflight Requests
+
+You may enable handling of CORS preflight requests for your routes using the `preflight` setting. This ensures that the router will respond to `OPTIONS` requests with a status code 200 and no content, allowing cross-origin requests to proceed.
+
+**Example**
+
+```php
+// single route
+SimpleRouter::form('foo', function () {
+    // ...
+})->setSettings(['preflight' => true]);
+
+// group routes
+SimpleRouter::group(['preflight' => true], function () {
+    SimpleRouter::form('foo', function() {
+        // ...
+    });
+});
+```
+
+- Requesting `OPTIONS /foo` will return `HTTP/1.1 200 OK`.
+- Requesting `POST /foo` will proceed normally.
 
 ### Regular expression constraints
 

--- a/src/Pecee/SimpleRouter/Route/Route.php
+++ b/src/Pecee/SimpleRouter/Route/Route.php
@@ -27,6 +27,13 @@ abstract class Route implements IRoute
     protected bool $slashParameterEnabled = false;
 
     /**
+     * Enables handling of CORS preflight requests.
+     * When true, the router responds to OPTIONS requests with status 200 and no content. Otherwise, it proceeds normally.
+     * @var bool
+     */
+    protected bool $preflightRequestsEnabled = false;
+
+    /**
      * Default regular expression used for parsing parameters.
      * @var string|null
      */
@@ -414,6 +421,17 @@ abstract class Route implements IRoute
         return $this->slashParameterEnabled;
     }
 
+    public function setPreflightRequestsEnabled(bool $enabled): self
+    {
+        $this->preflightRequestsEnabled = $enabled;
+        return $this;
+    }
+
+    public function getPreflightRequestsEnabled(): bool
+    {
+        return $this->preflightRequestsEnabled;
+    }
+
     /**
      * Export route settings to array so they can be merged with another route.
      *
@@ -445,6 +463,10 @@ abstract class Route implements IRoute
 
         if ($this->slashParameterEnabled === true) {
             $values['includeSlash'] = $this->slashParameterEnabled;
+        }
+
+        if ($this->preflightRequestsEnabled === true) {
+            $values['preflight'] = $this->preflightRequestsEnabled;
         }
 
         return $values;
@@ -486,6 +508,10 @@ abstract class Route implements IRoute
 
         if (isset($settings['includeSlash']) === true) {
             $this->setSlashParameterEnabled($settings['includeSlash']);
+        }
+
+        if (isset($settings['preflight']) === true) {
+            $this->setPreflightRequestsEnabled($settings['preflight']);
         }
 
         return $this;

--- a/src/Pecee/SimpleRouter/Router.php
+++ b/src/Pecee/SimpleRouter/Router.php
@@ -392,8 +392,9 @@ class Router
                         'route' => $route,
                     ]);
 
-                    /* Check if request method matches */
-                    if (count($route->getRequestMethods()) !== 0 && in_array($this->request->getMethod(), $route->getRequestMethods(), true) === false) {
+                    /* Check if request method does not match */
+                    if ((count($route->getRequestMethods()) !== 0 && in_array($this->request->getMethod(), $route->getRequestMethods(), true) === false) && 
+                        !($route->getPreflightRequestsEnabled() && $this->request->getMethod() === Request::REQUEST_TYPE_OPTIONS)) {
                         $this->debug('Method "%s" not allowed', $this->request->getMethod());
 
                         // Only set method not allowed is not already set
@@ -423,6 +424,10 @@ class Router
                     $this->fireEvents(EventHandler::EVENT_RENDER_ROUTE, [
                         'route' => $route,
                     ]);
+
+                    if ($route->getPreflightRequestsEnabled() && $this->request->getMethod() === Request::REQUEST_TYPE_OPTIONS) {
+                        return '';
+                    }
 
                     $routeOutput = $route->renderRoute($this->request, $this);
 

--- a/tests/Pecee/SimpleRouter/RouterRouteTest.php
+++ b/tests/Pecee/SimpleRouter/RouterRouteTest.php
@@ -81,6 +81,14 @@ class RouterRouteTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue(true);
     }
 
+    public function testOptions()
+    {
+        TestRouter::options('/my/test/url', 'DummyController@method1');
+        TestRouter::debug('/my/test/url', 'options');
+
+        $this->assertTrue(true);
+    }
+
     public function testMethodNotAllowed()
     {
         TestRouter::get('/my/test/url', 'DummyController@method1');
@@ -90,6 +98,14 @@ class RouterRouteTest extends \PHPUnit\Framework\TestCase
         } catch (\Exception $e) {
             $this->assertEquals(403, $e->getCode());
         }
+    }
+    
+    public function testPreflight()
+    {
+        TestRouter::get('/my/test/url', 'DummyController@method1', ['preflight' => true]);
+        TestRouter::debug('/my/test/url', 'options');
+    
+        $this->assertTrue(true);
     }
 
     public function testSimpleParam()


### PR DESCRIPTION
## Description

This pull request adds support for handling CORS preflight requests in the routing system. The router will respond to OPTIONS requests only when the route actually exists and a `preflight` setting is enabled. The setting is disabled by default.

## Changes

- Added a `preflight` setting to enable handling of preflight requests.
- When the setting is enabled, the router responds to `OPTIONS` requests with status `200 OK` and no content, following the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS#status_code).
- Added unit tests and README documentation.

## Usage

```php
// single route
SimpleRouter::form('foo', function () {
    // ...
})->setSettings(['preflight' => true]);

// group routes
SimpleRouter::group(['preflight' => true], function () {
    SimpleRouter::form('foo', function() {
        // ...
    });
});
```
- Requesting `OPTIONS /foo` will return `HTTP/1.1 200 OK`.
- Requesting `POST /foo` will proceed normally.

