### PR TITLE
Allow Middleware parameters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
   },
   "authors": [
     {
-      "name": "Michael Arawole",
-      "email": "michael@logad.net"
-    },
-    {
       "name": "Simon Sessingø",
       "email": "simon.sessingoe@gmail.com"
+    },
+    {
+      "name": "Michael Arawole",
+      "email": "michael@logad.net"
     }
   ],
   "require": {
@@ -49,7 +49,7 @@
   },
   "autoload": {
     "psr-4": {
-      "Pecee\\": "src/Pecee/"
+      "LogadApp\\": "src/Pecee/"
     }
   },
   "config": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "michaelthedev/simple-router",
-  "description": "Simple, fast PHP router that is easy to get integrated and in almost any project. Heavily inspired by the Laravel router.",
+  "description": "Simple, fast PHP router that is easy to get integrated and in almost any project. Heavily inspired by the Laravel router. (Forked from skipperbent/simple-php-router)",
   "keywords": [
     "router",
     "router",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "pecee/simple-router",
+  "name": "michaelthedev/simple-router",
   "description": "Simple, fast PHP router that is easy to get integrated and in almost any project. Heavily inspired by the Laravel router.",
   "keywords": [
     "router",

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,10 @@
   },
   "authors": [
     {
+      "name": "Michael Arawole",
+      "email": "michael@logad.net"
+    },
+    {
       "name": "Simon Sessingø",
       "email": "simon.sessingoe@gmail.com"
     }

--- a/src/Pecee/SimpleRouter/Route/LoadableRoute.php
+++ b/src/Pecee/SimpleRouter/Route/LoadableRoute.php
@@ -37,8 +37,19 @@ abstract class LoadableRoute extends Route implements ILoadableRoute
         $router->debug('Loading middlewares');
 
         foreach ($this->getMiddlewares() as $middleware) {
+			$parameters = [];
 
             if (is_object($middleware) === false) {
+				if (str_contains($middleware, ',')) {
+					$options = explode(',', $middleware);
+
+					//@todo: see efficiency of trim
+					$middleware = $options[0];
+
+					// set the rest of explode as parameters
+					$parameters = array_slice($options, 1);
+				}
+
                 $middleware = $router->getClassLoader()->loadClass($middleware);
             }
 
@@ -49,7 +60,7 @@ abstract class LoadableRoute extends Route implements ILoadableRoute
             $className = get_class($middleware);
 
             $router->debug('Loading middleware "%s"', $className);
-            $middleware->handle($request);
+            $middleware->handle($request, ...$parameters);
             $router->debug('Finished loading middleware "%s"', $className);
         }
 

--- a/tests/Pecee/SimpleRouter/Dummy/DummyMiddlewareWithParam.php
+++ b/tests/Pecee/SimpleRouter/Dummy/DummyMiddlewareWithParam.php
@@ -1,0 +1,14 @@
+<?php
+
+require_once 'Exception/MiddlewareLoadedException.php';
+
+use Pecee\Http\Request;
+
+class DummyMiddlewareWithParam implements \Pecee\Http\Middleware\IMiddleware
+{
+	public function handle(Request $request, ?string $val1 = null, ?string $val2 = null): void
+	{
+		throw new MiddlewareLoadedException('Middleware loaded! Param1: ' . $val1 . ' Param2: ' . $val2);
+	}
+
+}

--- a/tests/Pecee/SimpleRouter/MiddlewareTest.php
+++ b/tests/Pecee/SimpleRouter/MiddlewareTest.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once 'Dummy/DummyMiddleware.php';
+require_once 'Dummy/DummyMiddlewareWithParam.php';
 require_once 'Dummy/DummyController.php';
 require_once 'Dummy/Handler/ExceptionHandler.php';
 
@@ -32,4 +33,15 @@ class MiddlewareTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue(true);
     }
 
+	public function testMiddlewareWithParameters()
+	{
+		$this->expectException(MiddlewareLoadedException::class);
+
+		TestRouter::group(['exceptionHandler' => 'ExceptionHandler'], function () {
+			TestRouter::get('/my/test/url', 'DummyController@method1', ['middleware' => 'DummyMiddlewareWithParam,4,hello']);
+		});
+
+		TestRouter::debug('/my/test/url', 'get');
+
+	}
 }


### PR DESCRIPTION
Allows usage of comma separated values as middleware parameters

```php
Router::post('/purchase', [CableTvController::class, 'purchase'])
  ->addMiddleware(PinVerified::class.',value_1,value_2');
```

OR

```php
Router::post('/purchase', [CableTvController::class, 'purchase'])
  ->addMiddleware('App\Middlewares\TestMiddleware,value_1,value_2');
```